### PR TITLE
Support for custom scalars

### DIFF
--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -3,6 +3,7 @@
 using System; 
 using System.Linq; 
 using System.Text.Json.Serialization; 
+using ZeroQL; 
 
 #nullable enable
 
@@ -77,9 +78,6 @@ namespace GraphQL.TestServer
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
     public class Query : global::ZeroQL.Internal.IQuery
     {
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Instant")]
-        public Instant __Instant { get; set; }
-
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Me")]
         public User __Me { get; set; }
 
@@ -110,11 +108,7 @@ namespace GraphQL.TestServer
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Container")]
         public TypesContainer __Container { get; set; }
 
-        [ZeroQL.GraphQLFieldSelector]
-        public T Instant<T>(Func<Instant, T> selector)
-        {
-            return selector(__Instant);
-        }
+        public global::ZeroQL.Instant Instant { get; set; }
 
         [ZeroQL.GraphQLFieldSelector]
         public T Me<T>(Func<User, T> selector)

--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -77,6 +77,9 @@ namespace GraphQL.TestServer
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
     public class Query : global::ZeroQL.Internal.IQuery
     {
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Instant")]
+        public Instant __Instant { get; set; }
+
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Me")]
         public User __Me { get; set; }
 
@@ -106,6 +109,12 @@ namespace GraphQL.TestServer
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never), JsonPropertyName("Container")]
         public TypesContainer __Container { get; set; }
+
+        [ZeroQL.GraphQLFieldSelector]
+        public T Instant<T>(Func<Instant, T> selector)
+        {
+            return selector(__Instant);
+        }
 
         [ZeroQL.GraphQLFieldSelector]
         public T Me<T>(Func<User, T> selector)

--- a/src/TestApp/ZeroQL.TestApp/Program.cs
+++ b/src/TestApp/ZeroQL.TestApp/Program.cs
@@ -4,6 +4,8 @@ using System.IO; // do not remove this
 using System.Collections.Generic; // do not remove this
 using System.Threading.Tasks;
 using GraphQL.TestServer;
+using ZeroQL;
+using ZeroQL.Json; // do not remove this
 using ZeroQL.Schema; // do not remove this
 using ZeroQL.Pipelines; // do not remove this
 using ZeroQL.TestApp.Models;

--- a/src/TestApp/ZeroQL.TestApp/Scalars/Instant.cs
+++ b/src/TestApp/ZeroQL.TestApp/Scalars/Instant.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ZeroQL;
+
+public class Instant
+{
+    public DateTimeOffset DateTimeOffset { get; set; }
+}
+
+public class InstantJsonConverter : JsonConverter<Instant?>
+{
+    public override Instant? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var text = reader.GetString();
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+        return new Instant { DateTimeOffset = DateTimeOffset.Parse(text) };
+    }
+
+    public override void Write(Utf8JsonWriter writer, Instant? value, JsonSerializerOptions options)
+    {
+        var text = value?.DateTimeOffset.ToString("O");
+        writer.WriteStringValue(text);
+    }
+}

--- a/src/TestApp/ZeroQL.TestApp/ZeroQL.TestApp.csproj
+++ b/src/TestApp/ZeroQL.TestApp/ZeroQL.TestApp.csproj
@@ -10,4 +10,8 @@
         <ProjectReference Include="..\..\ZeroQL.Core\ZeroQL.Core.csproj" />
         <ProjectReference Include="..\..\ZeroQL.SourceGenerators\ZeroQL.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Generated" />
+    </ItemGroup>
 </Project>

--- a/src/TestApp/ZeroQL.TestApp/schema.graphql
+++ b/src/TestApp/ZeroQL.TestApp/schema.graphql
@@ -18,6 +18,7 @@ type Mutation {
 }
 
 type Query {
+  instant: Instant!
   me: User!
   users(filter: UserFilterInput! page: Int! size: Int!): [User!]!
   userKinds: [UserKind!]!
@@ -127,6 +128,9 @@ scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time"
 
 "The built-in `Decimal` scalar type."
 scalar Decimal
+
+"Represents an instant on the global timeline, with nanosecond resolution."
+scalar Instant
 
 "The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
 scalar Long

--- a/src/ZeroQL.Core/Bootstrap/GraphQLGenerator.cs
+++ b/src/ZeroQL.Core/Bootstrap/GraphQLGenerator.cs
@@ -42,8 +42,13 @@ public static class GraphQLGenerator
             .Type;
 
         var enumsNames = new HashSet<string>(enums.Select(o => o.Name.StringValue));
+        var scalarTypes = schema.Definitions
+            .OfType<GraphQLScalarTypeDefinition>()
+            .Select(o => o.Name.StringValue)
+            .ToArray();
 
-        var context = new TypeFormatter(enumsNames);
+        var context = new TypeFormatter(enumsNames, scalarTypes);
+        
         var inputs = schema.Definitions
             .OfType<GraphQLInputObjectTypeDefinition>()
             .Select(o => CreateInputDefinition(context, o))
@@ -53,7 +58,6 @@ public static class GraphQLGenerator
             .OfType<GraphQLObjectTypeDefinition>()
             .Select(o => CreateTypesDefinition(context, o))
             .ToArray();
-
 
         var namespaceDeclaration = NamespaceDeclaration(IdentifierName(clientNamespace));
         var clientDeclaration = new[] { GenerateClient(clientName, queryType, mutationType) };
@@ -75,6 +79,7 @@ public static class GraphQLGenerator
 using System; 
 using System.Linq; 
 using System.Text.Json.Serialization; 
+using ZeroQL; 
 
 #nullable enable
 

--- a/src/ZeroQL.Core/Internal/TypeFormatter.cs
+++ b/src/ZeroQL.Core/Internal/TypeFormatter.cs
@@ -20,13 +20,21 @@ internal class TypeFormatter
         { "DateTime", "DateTimeOffset" },
         { "Date", "DateOnly" },
         { "UUID", "Guid" },
-        { "Boolean", "bool" },
-        { "Upload", "global::ZeroQL.Upload" },
+        { "Boolean", "bool" }
     };
 
-    public TypeFormatter(HashSet<string> enums)
+    public TypeFormatter(HashSet<string> enums, string[] customScalars)
     {
         Enums = enums;
+        foreach (var scalar in customScalars)
+        {
+            if (GraphQLToCsharpScalarTypes.ContainsKey(scalar))
+            {
+                continue;
+            }
+            
+            GraphQLToCsharpScalarTypes[scalar] = $"global::ZeroQL.{scalar}";
+        }
     }
 
     public HashSet<string> Enums

--- a/src/ZeroQL.Core/Json/ZeroQLJsonOptions.cs
+++ b/src/ZeroQL.Core/Json/ZeroQLJsonOptions.cs
@@ -1,11 +1,19 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace ZeroQL.Json;
 
 public static class ZeroQLJsonOptions
 {
-    public static JsonSerializerOptions Options = new()
+    static ZeroQLJsonOptions()
+    {
+        Options = Create();
+    }
+
+    public static JsonSerializerOptions Options { get; private set; }
+
+    public static JsonSerializerOptions Create() => new()
     {
         Converters =
         {
@@ -17,4 +25,12 @@ public static class ZeroQLJsonOptions
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    public static void Configure(Action<JsonSerializerOptions> configure)
+    {
+        var newOptions = Create();
+        configure(newOptions);
+
+        Options = newOptions;
+    }
 }

--- a/src/ZeroQL.TestServer/Program.cs
+++ b/src/ZeroQL.TestServer/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using HotChocolate.Language;
+using HotChocolate.Types.NodaTime;
 using ZeroQL.TestServer.Query;
 using ZeroQL.TestServer.Query.Models;
 
@@ -30,6 +31,8 @@ public class Program
             .AddQueryType<Query.Query>()
             .AddMutationType<Mutation>()
             .AddType<UploadType>()
+            .AddType<InstantType>()
+            .AddTypeExtension<NodeTimeGraphQLExtensions>()
             .AddTypeExtension<UserGraphQLExtensions>()
             .AddTypeExtension<UserGraphQLMutations>()
             .AddTypeExtension<RoleGraphQLExtension>();

--- a/src/ZeroQL.TestServer/Query/NodeTimeGraphQLExtensions.cs
+++ b/src/ZeroQL.TestServer/Query/NodeTimeGraphQLExtensions.cs
@@ -1,0 +1,12 @@
+﻿using NodaTime;
+
+namespace ZeroQL.TestServer.Query;
+
+[ExtendObjectType(typeof(Query))]
+public class NodeTimeGraphQLExtensions
+{
+    public Instant GetInstant()
+    {
+        return Instant.FromDateTimeOffset(DateTimeOffset.Now);
+    }
+}

--- a/src/ZeroQL.TestServer/ZeroQL.TestServer.csproj
+++ b/src/ZeroQL.TestServer/ZeroQL.TestServer.csproj
@@ -7,9 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="12.13.0" />
-        <PackageReference Include="HotChocolate.PersistedQueries.FileSystem" Version="12.13.0" />
-        <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="12.13.0" />
+        <PackageReference Include="HotChocolate.AspNetCore" Version="12.15.0" />
+        <PackageReference Include="HotChocolate.PersistedQueries.FileSystem" Version="12.15.0" />
+        <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="12.15.0" />
+        <PackageReference Include="HotChocolate.Types.NodaTime" Version="12.15.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.cs
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.cs
@@ -318,7 +318,7 @@ public class ParseSchemaTests
     }
     
     [Fact]
-    public void InstantScalarIsDetected()
+    public void UserDefinedScalarIsDetected()
     {
         SyntaxTree.GetClass("Query")?
             .GetProperty("Instant")

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.cs
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.cs
@@ -316,4 +316,12 @@ public class ParseSchemaTests
         var genericName = (GenericNameSyntax)name.Right;
         genericName.TypeArgumentList.Arguments[1].ToString().Should().Be("Mutations");
     }
+    
+    [Fact]
+    public void InstantScalarIsDetected()
+    {
+        SyntaxTree.GetClass("Query")?
+            .GetProperty("Instant")
+            .Should().NotBeNull();
+    }
 }

--- a/src/ZeroQL.Tests/SourceGeneration/UserScalarTests.InstantScalarTypeWorks.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/UserScalarTests.InstantScalarTypeWorks.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  Query: query { instant},
+  Data: {
+    DateTimeOffset: DateTimeOffset_1
+  }
+}

--- a/src/ZeroQL.Tests/SourceGeneration/UserScalarTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/UserScalarTests.cs
@@ -1,0 +1,25 @@
+using ZeroQL.Tests.Core;
+using ZeroQL.Tests.Data;
+
+namespace ZeroQL.Tests.SourceGeneration;
+
+[UsesVerify]
+public class UserScalarTests: IntegrationTest
+{
+    [Fact]
+    public async Task InstantScalarTypeWorks()
+    {
+        var csharpQuery = "static q => q.Instant";
+        var graphqlQuery = @"query { instant}";
+
+        var project = await TestProject.Project
+            .ReplacePartOfDocumentAsync("Program.cs",
+                (TestProject.PLACE_TO_REPLACE, "global::ZeroQL.Json.ZeroQLJsonOptions.Configure(o => o.Converters.Add(new InstantJsonConverter()));"),
+                (TestProject.ME_QUERY, csharpQuery));
+
+        var response = await project.Validate(graphqlQuery, false);
+
+        await Verify(response);
+    }
+    
+}

--- a/src/ZeroQL.Tests/ZeroQL.Tests.csproj
+++ b/src/ZeroQL.Tests/ZeroQL.Tests.csproj
@@ -8,7 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="Verify.Xunit" Version="18.1.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request adds support for user-defined graphql scalars.

Let's suppose that server returns the `` Instant `` type from `` NodaTime ``.
The schema looks like that
``` graphql

"""
Represents an instant on the global timeline, with nanosecond resolution.
"""
scalar Instant

type Query {
  instant: Instant!
}
```

The ZeroQL knows nothing about the scalar type `` Instant ``, but we should be able to add support for it. To make it work, create the class `` Instant `` in the ZeroQL namespace and add a JSON serializer for it:
``` cs
namespace ZeroQL;

public class Instant
{
    public DateTimeOffset DateTimeOffset { get; set; }
}

public class InstantJsonConverter : JsonConverter<Instant?>
{
    public override Instant? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
    {
        var text = reader.GetString();
        if (string.IsNullOrEmpty(text))
        {
            return null;
        }
        return new Instant { DateTimeOffset = DateTimeOffset.Parse(text) };
    }

    public override void Write(Utf8JsonWriter writer, Instant? value, JsonSerializerOptions options)
    {
        var text = value?.DateTimeOffset.ToString("O");
        writer.WriteStringValue(text);
    }
}
```

Then, somewhere in your app, add this serializer to JSON options:
``` cs
ZeroQLJsonOptions.Configure(o => o.Converters.Add(new InstantJsonConverter()));
```
Now we are ready to consume it:
``` cs
var response = await qlClient.Query(static q => q.Instant);
```

Fixed #9 

