### PR TITLE
Implementation of support for different transports (other than Http)

### DIFF
--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -14,6 +14,10 @@ namespace GraphQL.TestServer
         public TestServerClient(global::System.Net.Http.HttpClient client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
         {
         }
+
+        public TestServerClient(global::ZeroQL.IGraphQLTransport transport, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(transport, queryPipeline)
+        {
+        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]

--- a/src/ZeroQL.Core/Bootstrap/GraphQLGenerator.cs
+++ b/src/ZeroQL.Core/Bootstrap/GraphQLGenerator.cs
@@ -114,8 +114,8 @@ public static class GraphQLGenerator
 
         return CSharpHelper.Class(clientName ?? "GraphQLClient")
             .WithBaseList(BaseList(SingletonSeparatedList<BaseTypeSyntax>(SimpleBaseType(IdentifierName($"global::ZeroQL.GraphQLClient<{queryTypeName}, {mutationTypeName}>")))))
-            .WithMembers(SingletonList<MemberDeclarationSyntax>(
-                ConstructorDeclaration(clientName ?? "GraphQLClient")
+            .WithMembers(List<MemberDeclarationSyntax>()
+                .Add(ConstructorDeclaration(clientName ?? "GraphQLClient")
                     .WithParameterList(ParseParameterList("(global::System.Net.Http.HttpClient client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null)"))
                     // call base constructor
                     .WithInitializer(ConstructorInitializer(SyntaxKind.BaseConstructorInitializer,
@@ -124,7 +124,18 @@ public static class GraphQLGenerator
                             .Add(Argument(IdentifierName("queryPipeline")))
                         )))
                     .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                    .WithBody(Block())));
+                    .WithBody(Block()))
+                .Add(ConstructorDeclaration(clientName ?? "GraphQLClient")
+                    .WithParameterList(ParseParameterList("(global::ZeroQL.IGraphQLTransport transport, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null)"))
+                    // call base constructor
+                    .WithInitializer(ConstructorInitializer(SyntaxKind.BaseConstructorInitializer,
+                        ArgumentList(SeparatedList<ArgumentSyntax>()
+                            .Add(Argument(IdentifierName("transport")))
+                            .Add(Argument(IdentifierName("queryPipeline")))
+                        )))
+                    .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                    .WithBody(Block()))
+            );
     }
 
     private static ClassDeclarationSyntax[] GenerateInputs(ClassDefinition[] inputs)

--- a/src/ZeroQL.Core/GraphQLClient.cs
+++ b/src/ZeroQL.Core/GraphQLClient.cs
@@ -10,8 +10,7 @@ namespace ZeroQL;
 
 public interface IGraphQLClient
 {
-    HttpClient HttpClient { get; }
-
+    IGraphQLTransport Transport { get; }
     IGraphQLQueryPipeline QueryPipeline { get; }
 
     Task<GraphQLResult<TResult>> Execute<TVariables, TOperationType, TResult>(
@@ -34,12 +33,18 @@ public class GraphQLClient<TQuery, TMutation> : IGraphQLClient, IDisposable
     }
 
     public GraphQLClient(HttpClient httpClient, IGraphQLQueryPipeline? queryPipeline = null)
+        : this(new HttpTransport(httpClient), queryPipeline)
     {
-        HttpClient = httpClient;
+
+    }
+
+    public GraphQLClient(IGraphQLTransport transport, IGraphQLQueryPipeline? queryPipeline = null)
+    {
+        Transport = transport;
         QueryPipeline = queryPipeline ?? new FullQueryPipeline();
     }
 
-    public HttpClient HttpClient { get; }
+    public IGraphQLTransport Transport { get; }
 
     public IGraphQLQueryPipeline QueryPipeline { get; }
 
@@ -64,6 +69,9 @@ public class GraphQLClient<TQuery, TMutation> : IGraphQLClient, IDisposable
 
     public void Dispose()
     {
-        HttpClient.Dispose();
+        if (Transport is IDisposable disposableTransport)
+        {
+            disposableTransport.Dispose();
+        }
     }
 }

--- a/src/ZeroQL.Core/GraphQLTransport.cs
+++ b/src/ZeroQL.Core/GraphQLTransport.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ZeroQL.Internal;
+using ZeroQL.Json;
+
+namespace ZeroQL;
+
+
+public interface IGraphQLTransport
+{
+	public IGraphQLTransportContent CreateContent(GraphQLRequest queryRequest);
+	public Task<GraphQLResponse<TQuery>> DeliverAsync<TQuery>(string query, IGraphQLTransportContent transportContent);
+}
+
+public class HttpTransport : IGraphQLTransport, IDisposable
+{
+	private HttpClient httpClient;
+
+    public HttpTransport(HttpClient httpClient)
+	{
+		this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+	}
+
+    public IGraphQLTransportContent CreateContent(GraphQLRequest queryRequest)
+	{
+		throw new Exception($"This method shouldn't get called.  Currently the source code to {nameof(CreateContent)} is dynamically generated and therefore isn't on this {nameof(HttpTransport)} class");
+	}
+
+
+    public async Task<GraphQLResponse<TQuery>> DeliverAsync<TQuery>(string query, IGraphQLTransportContent transportContent)
+	{
+		if (!(transportContent is HttpTransportContent httpTransportContent))
+			throw new ArgumentException($"{nameof(transportContent)} was not of type {typeof(HttpTransportContent)}.  Type={transportContent.GetType()}", nameof(transportContent));
+
+        var response = await httpClient.PostAsync("", httpTransportContent.HttpContent);
+        var responseJson = await response.Content.ReadAsStreamAsync();
+        var qlResponse = await JsonSerializer.DeserializeAsync<GraphQLResponse<TQuery>>(responseJson, ZeroQLJsonOptions.Options);
+
+		return qlResponse;
+    }
+
+
+    public void Dispose()
+	{
+		httpClient.Dispose();
+	}
+}

--- a/src/ZeroQL.Core/GraphQLTransportContent.cs
+++ b/src/ZeroQL.Core/GraphQLTransportContent.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net.Http;
+
+namespace ZeroQL;
+
+public interface IGraphQLTransportContent
+{
+}
+
+public class HttpTransportContent : IGraphQLTransportContent
+{
+	public HttpTransportContent(HttpContent httpContent)
+	{
+		HttpContent = httpContent ?? throw new ArgumentNullException(nameof(httpContent));
+	}
+
+	public HttpContent HttpContent { get; }
+}

--- a/src/ZeroQL.Core/Pipelines/IGraphQLQueryPipeline.cs
+++ b/src/ZeroQL.Core/Pipelines/IGraphQLQueryPipeline.cs
@@ -7,5 +7,5 @@ namespace ZeroQL.Pipelines;
 
 public interface IGraphQLQueryPipeline
 {
-    Task<GraphQLResponse<TQuery>> ExecuteAsync<TQuery>(HttpClient httpClient, string queryKey, object? variables, Func<GraphQLRequest, HttpContent> contentCreator);
+    Task<GraphQLResponse<TQuery>> ExecuteAsync<TQuery>(IGraphQLTransport transport, string queryKey, object? variables, Func<GraphQLRequest, IGraphQLTransportContent> contentCreator);
 }

--- a/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
+++ b/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
@@ -47,10 +47,15 @@ namespace {semanticModel.Compilation.Assembly.Name}
         public static async Task<GraphQLResult<{context.QueryTypeName}>> Execute(IGraphQLClient qlClient, string queryKey, object variablesObject)
         {{
             var variables = ({context.RequestExecutorInputSymbol.ToGlobalName()})variablesObject;
-            var qlResponse = await qlClient.QueryPipeline.ExecuteAsync<{context.QueryTypeName}>(qlClient.HttpClient, queryKey, variablesObject, queryRequest => 
+            var qlResponse = await qlClient.QueryPipeline.ExecuteAsync<{context.QueryTypeName}>(qlClient.Transport, queryKey, variablesObject, queryRequest => 
             {{
-                {GraphQLUploadResolver.GenerateRequestPreparations(graphQLInputTypeSafeName, typeInfo)}
-                return content;
+                if (qlClient.Transport is HttpTransport)
+                {{
+                    {GraphQLUploadResolver.GenerateRequestPreparations(graphQLInputTypeSafeName, typeInfo)}
+                    return new HttpTransportContent(content);
+                }}
+
+                return qlClient.Transport.CreateContent(queryRequest);
             }});
 
             if (qlResponse is null)

--- a/src/ZeroQL.Tests/HotChocolateIntegration/HotChocoTransport.cs
+++ b/src/ZeroQL.Tests/HotChocolateIntegration/HotChocoTransport.cs
@@ -1,0 +1,80 @@
+﻿using HotChocolate;
+using HotChocolate.AspNetCore.Serialization;
+using HotChocolate.Execution;
+using System.Text.Json;
+using ZeroQL.Json;
+using GraphQLRequest = ZeroQL.Internal.GraphQLRequest;
+
+namespace ZeroQL.Tests.HotChocolateIntegration;
+
+public class HotChocoTransport : IGraphQLTransport
+{
+    private IRequestExecutor requestExecutor;
+
+    public HotChocoTransport(IRequestExecutor requestExecutor)
+    {
+        this.requestExecutor = requestExecutor ?? throw new ArgumentNullException(nameof(requestExecutor));
+    }
+
+    public IGraphQLTransportContent CreateContent(GraphQLRequest queryRequest) =>
+        new HotChocoTransportContent(queryRequest.Query);
+
+    public async Task<GraphQLResponse<TQuery>> DeliverAsync<TQuery>(string query, IGraphQLTransportContent transportContent)
+    {
+        if (!(transportContent is HotChocoTransportContent hotChocoTransportContent))
+            throw new ArgumentException($"{nameof(transportContent)} was not of type {typeof(HotChocoTransportContent)}.  Type={transportContent.GetType()}", nameof(transportContent));
+
+        IExecutionResult executionResult = await requestExecutor.ExecuteAsync(hotChocoTransportContent.GraphQLRequest);
+
+        var errors = GetGraphQueryErrors(executionResult.Errors);
+        var extensions = executionResult.Extensions is null ? new Dictionary<string, object>() : new Dictionary<string, object>(executionResult.Extensions);
+        if (executionResult.Errors?.Any() ?? false)
+        {
+            return new GraphQLResponse<TQuery>() { Query = query, Errors = errors, Extensions = extensions };
+        }
+
+        var httpResultSerializer = new DefaultHttpResultSerializer();
+
+        //var responseJson = string.Empty;
+        using (MemoryStream memoryStream = new MemoryStream())
+        {
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            await httpResultSerializer.SerializeAsync(executionResult, memoryStream, cancellationTokenSource.Token);
+
+            memoryStream.Position = 0;
+
+            var response = await JsonSerializer.DeserializeAsync<GraphQLResponse<TQuery>>(memoryStream, ZeroQLJsonOptions.Options);
+            return response;
+        }
+    }
+
+    private GraphQueryError[] GetGraphQueryErrors(IReadOnlyList<IError> errors)
+    {
+        if (errors is null)
+            return null;
+
+        List<GraphQueryError> results = new();
+        foreach (var error in errors)
+        {
+            var graphQueryError = new GraphQueryError()
+            {
+                Message = error.Message
+            };
+
+            if (error.Path is not null)
+            {
+                graphQueryError.Path = new object[] { error.Path.Print() };
+            }
+
+            if (error.Extensions is not null)
+            {
+                graphQueryError.Extensions = new Dictionary<string, object>(error.Extensions);
+            }
+
+            results.Add(graphQueryError);
+        }
+
+        return results.ToArray();
+    }
+
+}

--- a/src/ZeroQL.Tests/HotChocolateIntegration/HotChocoTransportContent.cs
+++ b/src/ZeroQL.Tests/HotChocolateIntegration/HotChocoTransportContent.cs
@@ -1,0 +1,11 @@
+﻿namespace ZeroQL.Tests.HotChocolateIntegration;
+
+public class HotChocoTransportContent : IGraphQLTransportContent
+{
+	public HotChocoTransportContent(string graphqlRequest)
+	{
+		GraphQLRequest = !string.IsNullOrEmpty(graphqlRequest) ? graphqlRequest : throw new ArgumentNullException(nameof(graphqlRequest));
+	}
+
+	public string GraphQLRequest { get; }
+}

--- a/src/ZeroQL.Tests/SourceGeneration/TransportTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/TransportTests.cs
@@ -1,0 +1,26 @@
+﻿using GraphQL.TestServer;
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroQL.Tests.HotChocolateIntegration;
+using ZeroQL.TestServer;
+
+namespace ZeroQL.Tests.SourceGeneration;
+
+public class TransportTests
+{
+    [Fact]
+    public async Task SimpleQuery_HotChocolate_Without_Http_Endpoint()
+    {
+        //Setup HotChocolate pipeline
+        var serviceCollection = new ServiceCollection();
+        var requestExecutorBuilder = Program.AddBasicGraphQLServices(serviceCollection);
+        IRequestExecutor executor = await requestExecutorBuilder.BuildRequestExecutorAsync();
+
+        var zeroQLClient = new TestServerClient(new HotChocoTransport(executor));
+        var firstname = await zeroQLClient.Query(static q => q.Me(o => o.FirstName));
+
+        Assert.Null(firstname.Errors);
+        Assert.Equal("Jon", firstname.Data);
+    }
+
+}

--- a/src/ZeroQL.Tests/ZeroQL.Tests.csproj
+++ b/src/ZeroQL.Tests/ZeroQL.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -21,10 +21,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\TestApp\ZeroQL.TestApp\ZeroQL.TestApp.csproj" />
         <ProjectReference Include="..\ZeroQL.CLI\ZeroQL.CLI.csproj" />
         <ProjectReference Include="..\ZeroQL.Core\ZeroQL.Core.csproj" />
-        <ProjectReference Include="..\ZeroQL.SourceGenerators\ZeroQL.SourceGenerators.csproj" />
-        <ProjectReference Include="..\ZeroQL.TestServer\ZeroQL.TestServer.csproj" />
+		<ProjectReference Include="..\ZeroQL.SourceGenerators\ZeroQL.SourceGenerators.csproj" />
+		<ProjectReference Include="..\ZeroQL.TestServer\ZeroQL.TestServer.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The goal here is to have integration tests that still use the full Hot Chocolate pipeline, but don't require a TCP endpoint to be stood up.  Besides avoiding the network layer here, it further avoids having to have a background service (or process) running the server-side of things and (if your GraphQL requires it) removes authentication issues as well. 