### PR TITLE
Fix lexicographical mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As a result, the graphql client will be generated on every build.
 
 ## Config
 
-There is a way to simplify the CLI command. The command `` dotnet zeroql config init `` creates the `` zeroql.josn ``. It may look like that:
+There is a way to simplify the CLI command. The command `` dotnet zeroql config init `` creates the `` zeroql.json ``. It may look like that:
 ``` json
 {
   "$schema": "https://raw.githubusercontent.com/byme8/ZeroQL/main/schema.verified.json",


### PR DESCRIPTION
rename file extension from `josn` to `json` since second one is correct file extension for JSON files.