### PR TITLE
Escape Reserved Keywords in Generated C# Code

### DIFF
--- a/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
@@ -96,7 +96,7 @@ public static class TypeGenerator
 
             var parameters = field.Arguments
                 .Select(o =>
-                    Parameter(Identifier(o.Name))
+                    Parameter(Identifier(o.Name.EnsureNotKeyword()))
                         .WithType(ParseTypeName(o.TypeName)))
                 .ToArray();
 
@@ -134,7 +134,7 @@ public static class TypeGenerator
 
         var genericMethodWithType = MethodDeclaration(
                 IdentifierName(returnType),
-                Identifier(name))
+                Identifier(name.EnsureNotKeyword()))
             .AddModifiers(Token(SyntaxKind.PublicKeyword))
             .AddAttribute(ZeroQLGenerationInfo.GraphQLFieldSelectorAttribute, field.GraphQLName)
             .WithParameterList(ParameterList(list));

--- a/src/ZeroQL.Tools/Internal/CSharpHelper.cs
+++ b/src/ZeroQL.Tools/Internal/CSharpHelper.cs
@@ -113,4 +113,12 @@ internal static class CSharpHelper
                     .Select(o => Attribute(ParseName(o.Name), ParseAttributeArgumentList($"({o.Arguments})")))
                     .ToArray()));
     }
+
+    public static string EnsureNotKeyword(this string identifier)
+    {
+        if (SyntaxFacts.GetKeywordKind(identifier) is not SyntaxKind.None)
+            return $"@{identifier}";
+            
+        return identifier;
+    }
 }


### PR DESCRIPTION
This PR addresses an issue with the C# code generator. When a GraphQL schema contains reserved keywords as parameter names, the result is invalid C# code. 

For instance, a GraphQL schema like the one below:

```gql
type Query {
  example(object: Data): String
}
```

would generate the following invalid C# code:

```csharp
public string? Example(Data? object) // Syntax error
```

This is because `object` is a reserved keyword in C#.

To resolve this, the PR introduces a check in the generator to escape reserved keywords with the '@' character.

Using the same GraphQL schema as above, the generator now produces the following valid C# code:

```csharp
public string? Example(Data? @object) // Valid
```