### PR TITLE
use IHttpHandler in generated client constructor

### DIFF
--- a/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
+++ b/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
@@ -19,7 +19,7 @@ namespace GraphQL.TestServer
         {
         }
 
-        public TestServerClient(global::ZeroQL.HttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
+        public TestServerClient(global::ZeroQL.IHttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
         {
         }
     }

--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -19,7 +19,7 @@ namespace GraphQL.TestServer
         {
         }
 
-        public TestServerClient(global::ZeroQL.HttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
+        public TestServerClient(global::ZeroQL.IHttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
         {
         }
     }

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
@@ -19,7 +19,7 @@ namespace GraphQLClient
         {
         }
 
-        public TestApp(global::ZeroQL.HttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
+        public TestApp(global::ZeroQL.IHttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
         {
         }
     }

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
@@ -19,7 +19,7 @@ namespace GraphQLClient
         {
         }
 
-        public TestApp(global::ZeroQL.HttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
+        public TestApp(global::ZeroQL.IHttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null) : base(client, queryPipeline)
         {
         }
     }

--- a/src/ZeroQL.Tools/Bootstrap/Generators/GraphQLClientGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/Generators/GraphQLClientGenerator.cs
@@ -34,7 +34,7 @@ public static class GraphQLClientGenerator
                     .WithBody(Block()),
                 ConstructorDeclaration(clientName ?? "GraphQLClient")
                     .WithParameterList(ParseParameterList(
-                        "(global::ZeroQL.HttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null)"))
+                        "(global::ZeroQL.IHttpHandler client, global::ZeroQL.Pipelines.IGraphQLQueryPipeline? queryPipeline = null)"))
                     // call base constructor
                     .WithInitializer(ConstructorInitializer(SyntaxKind.BaseConstructorInitializer,
                         ArgumentList(SeparatedList<ArgumentSyntax>()


### PR DESCRIPTION
There is a small typo in the generated client. It references the HttpHandler class instead of the IHttpHandler interface.

Else it's working as expected. Thanks 👍 