### PR TITLE
Ensure data is always returned even with errors

### DIFF
--- a/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
+++ b/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
@@ -68,20 +68,11 @@ namespace {semanticModel.Compilation.Assembly.Name}
                 }};
             }}
 
-            if (qlResponse.Errors?.Length > 0)
-            {{
-                return new GraphQLResult<{context.QueryTypeName}>
-                {{
-                    Query = qlResponse.Query,
-                    Errors = qlResponse.Errors,
-                    Extensions = qlResponse.Extensions
-                }};
-            }}
-
             return new GraphQLResult<{context.QueryTypeName}>
             {{
                 Query = qlResponse.Query,
                 Data = qlResponse.Data,
+                Errors = qlResponse.Errors?.Length > 0 ? qlResponse.Errors : null,
                 Extensions = qlResponse.Extensions
             }};
         }}


### PR DESCRIPTION
I considered raising a bug/feature request but saw how it could be modified easily in code and went ahead and did it. I'm open to discuss this PR as I understand this is a not insignificant change.

I came across this problem while making queries to an externally managed system that occasionally throws errors when data cannot be matched behind the scenes. Using an Apollo Server instance to make queries I can see that in the data there are `null` values where this occurs which is what I want to see, but ZeroQL doesn't include data when any errors are raised. This change ensures that even when errors are included in a response, the data can still be examined, just like what Apollo Server does.

I'm not sure how likely this is to break other peoples' implementations, I wonder if it might be worthwhile considering a config toggle in that case?