### PR TITLE
Allow enum casting in GraphQL query.

### DIFF
--- a/src/TestApp/ZeroQL.TestApp/QueryFragments.cs
+++ b/src/TestApp/ZeroQL.TestApp/QueryFragments.cs
@@ -30,6 +30,14 @@ public static partial class QueryFragments
             Role = user.Role(o => o.Name)
         };
     }
+    
+    [GraphQLFragment]
+    public static UserRead AsUserRead(this User user) 
+        => new UserRead()
+        {
+            Id = user.Id,
+            Kind2 = (UserKind2)user.UserKind
+        };
 
     [GraphQLFragment]
     public static UserModel AsUserWithRoleNameExpression(this User user)

--- a/src/TestApp/ZeroQL.TestApp/User.cs
+++ b/src/TestApp/ZeroQL.TestApp/User.cs
@@ -4,9 +4,8 @@ public record UserModel
 {
     public UserModel()
     {
-        
     }
-    
+
     public UserModel(string firstName, string lastName, string? role)
     {
         FirstName = firstName;
@@ -14,21 +13,9 @@ public record UserModel
         Role = role;
     }
 
-    public string FirstName
-    {
-        get;
-        init;
-    }
+    public string FirstName { get; init; }
 
-    public string LastName
-    {
-        get;
-        init;
-    }
+    public string LastName { get; init; }
 
-    public string? Role
-    {
-        get;
-        init;
-    }
+    public string? Role { get; init; }
 }

--- a/src/TestApp/ZeroQL.TestApp/UserRead.cs
+++ b/src/TestApp/ZeroQL.TestApp/UserRead.cs
@@ -1,0 +1,14 @@
+namespace ZeroQL.TestApp;
+
+public class UserRead
+{
+    public ID Id { get; set; }
+    
+    public UserKind2 Kind2 { get; set; }
+}
+
+public enum UserKind2
+{
+    User,
+    Admin
+}

--- a/src/ZeroQL.SourceGenerators/Resolver/GraphQLQueryResolver.cs
+++ b/src/ZeroQL.SourceGenerators/Resolver/GraphQLQueryResolver.cs
@@ -293,6 +293,10 @@ public static class GraphQLQueryResolver
             {
                 return ResolveQuery(context.WithParent(arrowExpression), arrowExpression.Expression);
             }
+            case CastExpressionSyntax cast:
+            {
+                return HandleEnumCast(context, cast);
+            }
         }
 
         return Failed(node);
@@ -370,8 +374,9 @@ public static class GraphQLQueryResolver
         {
             return variable.GraphQLValue;
         }
-        
-        var possibleMethodSymbol = context.SemanticModel.GetSymbolInfo(argument.Parent!.Parent!, context.CancellationToken);
+
+        var possibleMethodSymbol =
+            context.SemanticModel.GetSymbolInfo(argument.Parent!.Parent!, context.CancellationToken);
         if (possibleMethodSymbol.Symbol is not IMethodSymbol methodSymbol)
         {
             return Failed(argument);
@@ -915,6 +920,23 @@ public static class GraphQLQueryResolver
         }
 
         return stringBuilder.ToString();
+    }
+
+    private static Result<string> HandleEnumCast(GraphQLResolveContext context, CastExpressionSyntax cast)
+    {
+        var castedTo = context.SemanticModel.GetTypeInfo(cast.Type);
+        if (castedTo.Type is null)
+        {
+            return Failed(cast);
+        }
+
+        var type = castedTo.Type;
+        if (type.TypeKind != TypeKind.Enum)
+        {
+            return Failed(cast);
+        }
+                
+        return ResolveQuery(context.WithParent(cast), cast.Expression);
     }
 
     private static bool IsUnionType(GraphQLResolveContext context, INamedTypeSymbol namedTypeSymbol)

--- a/src/ZeroQL.Tests/SourceGeneration/FragmentTests.CanApplyFragmentWithEnumCast.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/FragmentTests.CanApplyFragmentWithEnumCast.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  Query: query { me { id userKind } },
+  Data: {
+    Id: {
+      Value: 1
+    }
+  }
+}

--- a/src/ZeroQL.Tests/SourceGeneration/FragmentTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/FragmentTests.cs
@@ -57,6 +57,15 @@ public class FragmentTests : IntegrationTest
     }
     
     [Fact]
+    public async Task CanApplyFragmentWithEnumCast()
+    {
+        var csharpQuery = "q => q.Me(o => o.AsUserRead())";
+        var result = await TestProject.Project.Execute(csharpQuery);
+
+        await Verify(result);
+    }
+    
+    [Fact]
     public async Task CanApplyFragmentWithArgument()
     {
         var csharpQuery = "static (i, q) => q.GetUserById(i.Id)";

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.SupportForEnums.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.SupportForEnums.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  Query: query { me { id userKind } },
+  Data: {
+    Id: {
+      Value: 1
+    }
+  }
+}

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.SupportForEnumsWithCast.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.SupportForEnumsWithCast.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  Query: query { me { id userKind } },
+  Data: {
+    Id: {
+      Value: 1
+    }
+  }
+}

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.cs
@@ -237,13 +237,19 @@ public class QueryTests : IntegrationTest
     [Fact]
     public async Task SupportForEnums()
     {
-        var csharpQuery = "static q => q.Me(o => o.UserKind)";
-        var graphqlQuery = @"query { me { userKind } }";
-
-        var project = await TestProject.Project
-            .ReplacePartOfDocumentAsync("Program.cs", (TestProject.MeQuery, csharpQuery));
-
-        await project.Validate(graphqlQuery);
+        var query = "q => q.Me(o => new { o.Id, o.UserKind })";
+        var response = await TestProject.Project.Execute(query);
+        
+        await Verify(response);
+    }
+    
+    [Fact]
+    public async Task SupportForEnumsWithCast()
+    {
+        var query = "q => q.Me(o => new { Id = o.Id, UserKind = (UserKind)o.UserKind })";
+        var response = await TestProject.Project.Execute(query);
+        
+        await Verify(response);
     }
 
     [Fact]


### PR DESCRIPTION
At the moment, ZeroQL will report the error once you try to cast the enum. It is a trivial thing to do and this use case should be supported.

This PR allows to cast enums inside the GraphQL. 

Fixes #99