### PR TITLE
Fix type replacement inside the nullable array.

### DIFF
--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
@@ -1,0 +1,21 @@
+﻿[  
+    [ZeroQL.GraphQLType("Staff")]
+    [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
+    public class StaffZeroQL
+    {
+        [ZeroQL.GraphQLName("id")]
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("staff")]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public StaffZeroQL? []? __Staff { get; set; }
+
+        [ZeroQL.GraphQLName("staff")]
+        public T?[]? Staff<T>(Func<StaffZeroQL, T> selector = default !)
+        {
+            return __Staff?.Select(o => o is null ? default : selector(o)).ToArray();
+        }
+    }
+
+]

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.cs
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.cs
@@ -295,6 +295,37 @@ public class CustomSchemaParseTests
 
         await Verify(clases);
     }
+    
+    [Fact]
+    public async Task IdenticalNamesForArrayReplaced()
+    {
+      var rawSchema = @"
+            schema {
+              query: Query
+            }
+              
+            type Query {
+              staff: Staff!
+            }
+
+            type Staff {
+              id: Int!
+              staff: [Staff]
+            }
+        ";
+
+      var csharp = GraphQLGenerator.ToCSharp(rawSchema, "TestApp", "GraphQLClient");
+      var syntaxTree = CSharpSyntaxTree.ParseText(csharp);
+
+      var clases = (await syntaxTree.GetRootAsync())
+        .DescendantNodes()
+        .OfType<ClassDeclarationSyntax>()
+        .Where(o => o.Identifier.ValueText.Contains("Staff"))
+        .Select(o => o.ToFullString())
+        .ToArray();
+
+      await Verify(clases);
+    }
 
     [Fact]
     public async Task InputTypeNameIdenticalToPropertyName()

--- a/src/ZeroQL.Tests/ZeroQL.Tests.csproj
+++ b/src/ZeroQL.Tests/ZeroQL.Tests.csproj
@@ -29,16 +29,4 @@
         <ProjectReference Include="..\ZeroQL.TestServer\ZeroQL.TestServer.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <None Update="SourceGeneration\OptionalParametersDetectionTests.AppliedToWrongType.verified.txt">
-        <ParentFile>OnSyntaxTests</ParentFile>
-        <DependentUpon>OptionalParametersDetectionTests.cs</DependentUpon>
-      </None>
-      <None Update="SourceGeneration\OptionalParametersDetectionTests.Union.verified.txt">
-        <ParentFile>OnSyntaxTests</ParentFile>
-        <DependentUpon>OptionalParametersDetectionTests.cs</DependentUpon>
-      </None>
-      <None Remove="SourceGeneration\OptionalParametersDetectionTests.Interfaces.verified.txt" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The ZeroQL replaces type names when property names are identical. However, it was not correctly doing it for nullable type inside nullable array.

This PR fixes the issue.

Fixes #102 