### PR TITLE
Mark "__" properties as internal to avoid issues once removed

### DIFF
--- a/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
+++ b/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
@@ -36,8 +36,8 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __Center { get; set; }
 
         [ZeroQL.GraphQLName("center")]
@@ -55,8 +55,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Person? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -96,8 +96,8 @@ namespace GraphQL.TestServer
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithError? __ContainerWithError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithError")]
@@ -116,8 +116,8 @@ namespace GraphQL.TestServer
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -127,8 +127,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -155,8 +155,8 @@ namespace GraphQL.TestServer
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -210,8 +210,8 @@ namespace GraphQL.TestServer
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __Limit2 { get; set; }
 
         [ZeroQL.GraphQLName("limit2")]
@@ -244,8 +244,8 @@ namespace GraphQL.TestServer
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQL.TestServer.uuid __CreateUserId { get; set; }
 
         [ZeroQL.GraphQLName("createUserId")]
@@ -255,8 +255,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTime")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTime { get; set; }
 
         [ZeroQL.GraphQLName("dateTime")]
@@ -266,8 +266,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimes")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
         [ZeroQL.GraphQLName("dateTimes")]
@@ -277,8 +277,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimeOffset")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
         [ZeroQL.GraphQLName("dateTimeOffset")]
@@ -288,8 +288,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeSpan")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeSpan { get; set; }
 
         [ZeroQL.GraphQLName("timeSpan")]
@@ -299,8 +299,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateOnly __DateOnly { get; set; }
 
         [ZeroQL.GraphQLName("dateOnly")]
@@ -310,8 +310,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeOnly { get; set; }
 
         [ZeroQL.GraphQLName("timeOnly")]
@@ -321,8 +321,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("createInstant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQL.TestServer.Instant __CreateInstant { get; set; }
 
         [ZeroQL.GraphQLName("createInstant")]
@@ -332,8 +332,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __AddUser { get; set; }
 
         [ZeroQL.GraphQLName("addUser")]
@@ -347,8 +347,8 @@ namespace GraphQL.TestServer
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addUserProfileImage")]
@@ -358,8 +358,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addMyProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddMyProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addMyProfileImage")]
@@ -369,8 +369,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfo")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfo { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfo")]
@@ -380,8 +380,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfoWithEmails { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfoWithEmails")]
@@ -391,8 +391,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUserKindPascal")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserKindPascal { get; set; }
 
         [ZeroQL.GraphQLName("addUserKindPascal")]
@@ -402,8 +402,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __AddLimit { get; set; }
 
         [ZeroQL.GraphQLName("addLimit")]
@@ -413,8 +413,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimitNullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimitNullable")]
@@ -424,8 +424,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2")]
@@ -435,8 +435,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2Nullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2Nullable")]
@@ -446,8 +446,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit3")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit3? __AddLimit3 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit3")]
@@ -457,8 +457,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimits")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
         [ZeroQL.GraphQLName("addLimits")]
@@ -468,8 +468,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
         [ZeroQL.GraphQLName("addLowerCaseTypeName")]
@@ -479,8 +479,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addValues")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddValues { get; set; }
 
         [ZeroQL.GraphQLName("addValues")]
@@ -538,8 +538,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -566,8 +566,8 @@ namespace GraphQL.TestServer
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Int { get; set; }
 
         [ZeroQL.GraphQLName("int")]
@@ -577,8 +577,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("object")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Object { get; set; }
 
         [ZeroQL.GraphQLName("object")]
@@ -588,8 +588,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("containerWithoutError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithoutError")]
@@ -599,8 +599,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("entities")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IEntity[] __Entities { get; set; }
 
         [ZeroQL.GraphQLName("entities")]
@@ -610,8 +610,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figures")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure[] __Figures { get; set; }
 
         [ZeroQL.GraphQLName("figures")]
@@ -621,8 +621,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("circles")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Circle[] __Circles { get; set; }
 
         [ZeroQL.GraphQLName("circles")]
@@ -632,8 +632,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("squares")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Square[] __Squares { get; set; }
 
         [ZeroQL.GraphQLName("squares")]
@@ -647,8 +647,8 @@ namespace GraphQL.TestServer
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public JsonDocument __JsonUsersDocument { get; set; }
 
         [ZeroQL.GraphQLName("jsonUsersDocument")]
@@ -670,8 +670,8 @@ namespace GraphQL.TestServer
         public global::GraphQL.TestServer.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public PostContent[] __Posts { get; set; }
 
         [ZeroQL.GraphQLName("posts")]
@@ -681,8 +681,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("image")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ImageContent __Image { get; set; }
 
         [ZeroQL.GraphQLName("image")]
@@ -692,8 +692,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("text")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TextContent __Text { get; set; }
 
         [ZeroQL.GraphQLName("text")]
@@ -703,8 +703,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public FigureContent __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -714,8 +714,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("me")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Me { get; set; }
 
         [ZeroQL.GraphQLName("me")]
@@ -725,8 +725,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("currentUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __CurrentUser { get; set; }
 
         [ZeroQL.GraphQLName("currentUser")]
@@ -737,8 +737,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MEWITHSUPPERCASING { get; set; }
 
         [ZeroQL.GraphQLName("MEWITHSUPPERCASING")]
@@ -748,8 +748,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MeWithPascalCasing { get; set; }
 
         [ZeroQL.GraphQLName("MeWithPascalCasing")]
@@ -759,8 +759,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("users")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __Users { get; set; }
 
         [ZeroQL.GraphQLName("users")]
@@ -778,8 +778,8 @@ namespace GraphQL.TestServer
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[][] __UsersMatrix { get; set; }
 
         [ZeroQL.GraphQLName("usersMatrix")]
@@ -789,8 +789,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByKind { get; set; }
 
         [ZeroQL.GraphQLName("usersByKind")]
@@ -800,8 +800,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int[] __UsersIds { get; set; }
 
         [ZeroQL.GraphQLName("usersIds")]
@@ -811,8 +811,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("user")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __User { get; set; }
 
         [ZeroQL.GraphQLName("user")]
@@ -822,8 +822,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByIds { get; set; }
 
         [ZeroQL.GraphQLName("usersByIds")]
@@ -833,8 +833,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("userKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserKind __UserKind { get; set; }
 
         [ZeroQL.GraphQLName("userKind")]
@@ -844,8 +844,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("admin")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __Admin { get; set; }
 
         [ZeroQL.GraphQLName("admin")]
@@ -855,8 +855,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("container")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TypesContainer __Container { get; set; }
 
         [ZeroQL.GraphQLName("container")]
@@ -884,8 +884,8 @@ namespace GraphQL.TestServer
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -899,8 +899,8 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __TopLeft { get; set; }
 
         [ZeroQL.GraphQLName("topLeft")]
@@ -910,8 +910,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("bottomRight")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __BottomRight { get; set; }
 
         [ZeroQL.GraphQLName("bottomRight")]
@@ -944,8 +944,8 @@ namespace GraphQL.TestServer
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -1068,8 +1068,8 @@ namespace GraphQL.TestServer
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
         [ZeroQL.GraphQLName("value27")]
@@ -1079,8 +1079,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value28")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
         [ZeroQL.GraphQLName("value28")]
@@ -1090,8 +1090,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value29")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
         [ZeroQL.GraphQLName("value29")]
@@ -1101,8 +1101,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value30")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
         [ZeroQL.GraphQLName("value30")]
@@ -1141,8 +1141,8 @@ namespace GraphQL.TestServer
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Role? __Role { get; set; }
 
         [ZeroQL.GraphQLName("role")]
@@ -1152,8 +1152,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("loginAttempts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
         [ZeroQL.GraphQLName("loginAttempts")]
@@ -1204,8 +1204,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -1224,8 +1224,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]

--- a/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
+++ b/src/TestApp/TestStandardLibrary/Generated/GraphQL.g.cs
@@ -4,7 +4,7 @@
 //
 // Do not modify this file manually. Any changes will be lost after regeneration.
 // </auto-generated>
-#pragma warning disable 8618, CS8603, CS1066
+#pragma warning disable 8618, CS8603, CS1066, CS0618
 #nullable enable
 namespace GraphQL.TestServer
 {
@@ -36,6 +36,7 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __Center { get; set; }
 
@@ -54,6 +55,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Person? __Creator { get; set; }
 
@@ -94,6 +96,7 @@ namespace GraphQL.TestServer
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithError? __ContainerWithError { get; set; }
 
@@ -113,6 +116,7 @@ namespace GraphQL.TestServer
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure __Figure { get; set; }
 
@@ -123,6 +127,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -150,6 +155,7 @@ namespace GraphQL.TestServer
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -204,6 +210,7 @@ namespace GraphQL.TestServer
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __Limit2 { get; set; }
 
@@ -237,6 +244,7 @@ namespace GraphQL.TestServer
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQL.TestServer.uuid __CreateUserId { get; set; }
 
@@ -247,6 +255,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTime")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTime { get; set; }
 
@@ -257,6 +266,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimes")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
@@ -267,6 +277,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimeOffset")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
@@ -277,6 +288,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeSpan")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeSpan { get; set; }
 
@@ -287,6 +299,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateOnly __DateOnly { get; set; }
 
@@ -297,6 +310,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeOnly { get; set; }
 
@@ -307,6 +321,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("createInstant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQL.TestServer.Instant __CreateInstant { get; set; }
 
@@ -317,6 +332,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __AddUser { get; set; }
 
@@ -331,6 +347,7 @@ namespace GraphQL.TestServer
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserProfileImage { get; set; }
 
@@ -341,6 +358,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addMyProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddMyProfileImage { get; set; }
 
@@ -351,6 +369,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfo")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfo { get; set; }
 
@@ -361,6 +380,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfoWithEmails { get; set; }
 
@@ -371,6 +391,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUserKindPascal")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserKindPascal { get; set; }
 
@@ -381,6 +402,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __AddLimit { get; set; }
 
@@ -391,6 +413,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimitNullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
@@ -401,6 +424,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
@@ -411,6 +435,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2Nullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
@@ -421,6 +446,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit3")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit3? __AddLimit3 { get; set; }
 
@@ -431,6 +457,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimits")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
@@ -441,6 +468,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
@@ -451,6 +479,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addValues")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddValues { get; set; }
 
@@ -509,6 +538,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson __Creator { get; set; }
 
@@ -536,6 +566,7 @@ namespace GraphQL.TestServer
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Int { get; set; }
 
@@ -546,6 +577,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("object")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Object { get; set; }
 
@@ -556,6 +588,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("containerWithoutError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
@@ -566,6 +599,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("entities")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IEntity[] __Entities { get; set; }
 
@@ -576,6 +610,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figures")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure[] __Figures { get; set; }
 
@@ -586,6 +621,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("circles")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Circle[] __Circles { get; set; }
 
@@ -596,6 +632,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("squares")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Square[] __Squares { get; set; }
 
@@ -610,6 +647,7 @@ namespace GraphQL.TestServer
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public JsonDocument __JsonUsersDocument { get; set; }
 
@@ -632,6 +670,7 @@ namespace GraphQL.TestServer
         public global::GraphQL.TestServer.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public PostContent[] __Posts { get; set; }
 
@@ -642,6 +681,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("image")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ImageContent __Image { get; set; }
 
@@ -652,6 +692,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("text")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TextContent __Text { get; set; }
 
@@ -662,6 +703,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public FigureContent __Figure { get; set; }
 
@@ -672,6 +714,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("me")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Me { get; set; }
 
@@ -682,6 +725,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("currentUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __CurrentUser { get; set; }
 
@@ -693,6 +737,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MEWITHSUPPERCASING { get; set; }
 
@@ -703,6 +748,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MeWithPascalCasing { get; set; }
 
@@ -713,6 +759,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("users")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __Users { get; set; }
 
@@ -731,6 +778,7 @@ namespace GraphQL.TestServer
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[][] __UsersMatrix { get; set; }
 
@@ -741,6 +789,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByKind { get; set; }
 
@@ -751,6 +800,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int[] __UsersIds { get; set; }
 
@@ -761,6 +811,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("user")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __User { get; set; }
 
@@ -771,6 +822,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByIds { get; set; }
 
@@ -781,6 +833,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("userKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserKind __UserKind { get; set; }
 
@@ -791,6 +844,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("admin")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __Admin { get; set; }
 
@@ -801,6 +855,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("container")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TypesContainer __Container { get; set; }
 
@@ -829,6 +884,7 @@ namespace GraphQL.TestServer
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -843,6 +899,7 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __TopLeft { get; set; }
 
@@ -853,6 +910,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("bottomRight")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __BottomRight { get; set; }
 
@@ -886,6 +944,7 @@ namespace GraphQL.TestServer
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -1009,6 +1068,7 @@ namespace GraphQL.TestServer
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
@@ -1019,6 +1079,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value28")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
@@ -1029,6 +1090,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value29")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
@@ -1039,6 +1101,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value30")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
@@ -1078,6 +1141,7 @@ namespace GraphQL.TestServer
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Role? __Role { get; set; }
 
@@ -1088,6 +1152,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("loginAttempts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
@@ -1139,6 +1204,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -1158,6 +1224,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 

--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -36,8 +36,8 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __Center { get; set; }
 
         [ZeroQL.GraphQLName("center")]
@@ -55,8 +55,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Person? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -96,8 +96,8 @@ namespace GraphQL.TestServer
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithError? __ContainerWithError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithError")]
@@ -116,8 +116,8 @@ namespace GraphQL.TestServer
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -127,8 +127,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -155,8 +155,8 @@ namespace GraphQL.TestServer
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -210,8 +210,8 @@ namespace GraphQL.TestServer
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __Limit2 { get; set; }
 
         [ZeroQL.GraphQLName("limit2")]
@@ -244,8 +244,8 @@ namespace GraphQL.TestServer
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::System.Guid __CreateUserId { get; set; }
 
         [ZeroQL.GraphQLName("createUserId")]
@@ -255,8 +255,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTime")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTime { get; set; }
 
         [ZeroQL.GraphQLName("dateTime")]
@@ -266,8 +266,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimes")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
         [ZeroQL.GraphQLName("dateTimes")]
@@ -277,8 +277,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimeOffset")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
         [ZeroQL.GraphQLName("dateTimeOffset")]
@@ -288,8 +288,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeSpan")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeSpan { get; set; }
 
         [ZeroQL.GraphQLName("timeSpan")]
@@ -299,8 +299,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateOnly __DateOnly { get; set; }
 
         [ZeroQL.GraphQLName("dateOnly")]
@@ -310,8 +310,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeOnly { get; set; }
 
         [ZeroQL.GraphQLName("timeOnly")]
@@ -321,8 +321,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("createInstant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::ZeroQL.Instant __CreateInstant { get; set; }
 
         [ZeroQL.GraphQLName("createInstant")]
@@ -332,8 +332,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __AddUser { get; set; }
 
         [ZeroQL.GraphQLName("addUser")]
@@ -347,8 +347,8 @@ namespace GraphQL.TestServer
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addUserProfileImage")]
@@ -358,8 +358,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addMyProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddMyProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addMyProfileImage")]
@@ -369,8 +369,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfo")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfo { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfo")]
@@ -380,8 +380,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfoWithEmails { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfoWithEmails")]
@@ -391,8 +391,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUserKindPascal")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserKindPascal { get; set; }
 
         [ZeroQL.GraphQLName("addUserKindPascal")]
@@ -402,8 +402,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __AddLimit { get; set; }
 
         [ZeroQL.GraphQLName("addLimit")]
@@ -413,8 +413,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimitNullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimitNullable")]
@@ -424,8 +424,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2")]
@@ -435,8 +435,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2Nullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2Nullable")]
@@ -446,8 +446,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit3")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit3? __AddLimit3 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit3")]
@@ -457,8 +457,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimits")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
         [ZeroQL.GraphQLName("addLimits")]
@@ -468,8 +468,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
         [ZeroQL.GraphQLName("addLowerCaseTypeName")]
@@ -479,8 +479,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addValues")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddValues { get; set; }
 
         [ZeroQL.GraphQLName("addValues")]
@@ -538,8 +538,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -566,8 +566,8 @@ namespace GraphQL.TestServer
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Int { get; set; }
 
         [ZeroQL.GraphQLName("int")]
@@ -577,8 +577,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("object")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Object { get; set; }
 
         [ZeroQL.GraphQLName("object")]
@@ -588,8 +588,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("containerWithoutError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithoutError")]
@@ -599,8 +599,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("entities")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IEntity[] __Entities { get; set; }
 
         [ZeroQL.GraphQLName("entities")]
@@ -610,8 +610,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figures")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure[] __Figures { get; set; }
 
         [ZeroQL.GraphQLName("figures")]
@@ -621,8 +621,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("circles")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Circle[] __Circles { get; set; }
 
         [ZeroQL.GraphQLName("circles")]
@@ -632,8 +632,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("squares")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Square[] __Squares { get; set; }
 
         [ZeroQL.GraphQLName("squares")]
@@ -647,8 +647,8 @@ namespace GraphQL.TestServer
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public JsonDocument __JsonUsersDocument { get; set; }
 
         [ZeroQL.GraphQLName("jsonUsersDocument")]
@@ -670,8 +670,8 @@ namespace GraphQL.TestServer
         public global::GraphQL.TestServer.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public PostContent[] __Posts { get; set; }
 
         [ZeroQL.GraphQLName("posts")]
@@ -681,8 +681,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("image")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ImageContent __Image { get; set; }
 
         [ZeroQL.GraphQLName("image")]
@@ -692,8 +692,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("text")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TextContent __Text { get; set; }
 
         [ZeroQL.GraphQLName("text")]
@@ -703,8 +703,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public FigureContent __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -714,8 +714,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("me")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Me { get; set; }
 
         [ZeroQL.GraphQLName("me")]
@@ -725,8 +725,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("currentUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __CurrentUser { get; set; }
 
         [ZeroQL.GraphQLName("currentUser")]
@@ -737,8 +737,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MEWITHSUPPERCASING { get; set; }
 
         [ZeroQL.GraphQLName("MEWITHSUPPERCASING")]
@@ -748,8 +748,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MeWithPascalCasing { get; set; }
 
         [ZeroQL.GraphQLName("MeWithPascalCasing")]
@@ -759,8 +759,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("users")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __Users { get; set; }
 
         [ZeroQL.GraphQLName("users")]
@@ -778,8 +778,8 @@ namespace GraphQL.TestServer
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[][] __UsersMatrix { get; set; }
 
         [ZeroQL.GraphQLName("usersMatrix")]
@@ -789,8 +789,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByKind { get; set; }
 
         [ZeroQL.GraphQLName("usersByKind")]
@@ -800,8 +800,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int[] __UsersIds { get; set; }
 
         [ZeroQL.GraphQLName("usersIds")]
@@ -811,8 +811,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("user")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __User { get; set; }
 
         [ZeroQL.GraphQLName("user")]
@@ -822,8 +822,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByIds { get; set; }
 
         [ZeroQL.GraphQLName("usersByIds")]
@@ -833,8 +833,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("userKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserKind __UserKind { get; set; }
 
         [ZeroQL.GraphQLName("userKind")]
@@ -844,8 +844,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("admin")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __Admin { get; set; }
 
         [ZeroQL.GraphQLName("admin")]
@@ -855,8 +855,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("container")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TypesContainer __Container { get; set; }
 
         [ZeroQL.GraphQLName("container")]
@@ -884,8 +884,8 @@ namespace GraphQL.TestServer
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -899,8 +899,8 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __TopLeft { get; set; }
 
         [ZeroQL.GraphQLName("topLeft")]
@@ -910,8 +910,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("bottomRight")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __BottomRight { get; set; }
 
         [ZeroQL.GraphQLName("bottomRight")]
@@ -944,8 +944,8 @@ namespace GraphQL.TestServer
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -1068,8 +1068,8 @@ namespace GraphQL.TestServer
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
         [ZeroQL.GraphQLName("value27")]
@@ -1079,8 +1079,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value28")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
         [ZeroQL.GraphQLName("value28")]
@@ -1090,8 +1090,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value29")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
         [ZeroQL.GraphQLName("value29")]
@@ -1101,8 +1101,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value30")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
         [ZeroQL.GraphQLName("value30")]
@@ -1141,8 +1141,8 @@ namespace GraphQL.TestServer
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Role? __Role { get; set; }
 
         [ZeroQL.GraphQLName("role")]
@@ -1152,8 +1152,8 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("loginAttempts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
         [ZeroQL.GraphQLName("loginAttempts")]
@@ -1204,8 +1204,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -1224,8 +1224,8 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]

--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -4,7 +4,7 @@
 //
 // Do not modify this file manually. Any changes will be lost after regeneration.
 // </auto-generated>
-#pragma warning disable 8618, CS8603, CS1066
+#pragma warning disable 8618, CS8603, CS1066, CS0618
 #nullable enable
 namespace GraphQL.TestServer
 {
@@ -36,6 +36,7 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __Center { get; set; }
 
@@ -54,6 +55,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Person? __Creator { get; set; }
 
@@ -94,6 +96,7 @@ namespace GraphQL.TestServer
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithError? __ContainerWithError { get; set; }
 
@@ -113,6 +116,7 @@ namespace GraphQL.TestServer
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure __Figure { get; set; }
 
@@ -123,6 +127,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -150,6 +155,7 @@ namespace GraphQL.TestServer
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -204,6 +210,7 @@ namespace GraphQL.TestServer
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __Limit2 { get; set; }
 
@@ -237,6 +244,7 @@ namespace GraphQL.TestServer
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::System.Guid __CreateUserId { get; set; }
 
@@ -247,6 +255,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTime")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTime { get; set; }
 
@@ -257,6 +266,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimes")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
@@ -267,6 +277,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateTimeOffset")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
@@ -277,6 +288,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeSpan")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeSpan { get; set; }
 
@@ -287,6 +299,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("dateOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateOnly __DateOnly { get; set; }
 
@@ -297,6 +310,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("timeOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeOnly { get; set; }
 
@@ -307,6 +321,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("createInstant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::ZeroQL.Instant __CreateInstant { get; set; }
 
@@ -317,6 +332,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __AddUser { get; set; }
 
@@ -331,6 +347,7 @@ namespace GraphQL.TestServer
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserProfileImage { get; set; }
 
@@ -341,6 +358,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addMyProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddMyProfileImage { get; set; }
 
@@ -351,6 +369,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfo")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfo { get; set; }
 
@@ -361,6 +380,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfoWithEmails { get; set; }
 
@@ -371,6 +391,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addUserKindPascal")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserKindPascal { get; set; }
 
@@ -381,6 +402,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __AddLimit { get; set; }
 
@@ -391,6 +413,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimitNullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
@@ -401,6 +424,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
@@ -411,6 +435,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit2Nullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
@@ -421,6 +446,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimit3")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit3? __AddLimit3 { get; set; }
 
@@ -431,6 +457,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLimits")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
@@ -441,6 +468,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
@@ -451,6 +479,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("addValues")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddValues { get; set; }
 
@@ -509,6 +538,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson __Creator { get; set; }
 
@@ -536,6 +566,7 @@ namespace GraphQL.TestServer
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Int { get; set; }
 
@@ -546,6 +577,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("object")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Object { get; set; }
 
@@ -556,6 +588,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("containerWithoutError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
@@ -566,6 +599,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("entities")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IEntity[] __Entities { get; set; }
 
@@ -576,6 +610,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figures")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure[] __Figures { get; set; }
 
@@ -586,6 +621,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("circles")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Circle[] __Circles { get; set; }
 
@@ -596,6 +632,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("squares")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Square[] __Squares { get; set; }
 
@@ -610,6 +647,7 @@ namespace GraphQL.TestServer
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public JsonDocument __JsonUsersDocument { get; set; }
 
@@ -632,6 +670,7 @@ namespace GraphQL.TestServer
         public global::GraphQL.TestServer.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public PostContent[] __Posts { get; set; }
 
@@ -642,6 +681,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("image")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ImageContent __Image { get; set; }
 
@@ -652,6 +692,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("text")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TextContent __Text { get; set; }
 
@@ -662,6 +703,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public FigureContent __Figure { get; set; }
 
@@ -672,6 +714,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("me")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Me { get; set; }
 
@@ -682,6 +725,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("currentUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __CurrentUser { get; set; }
 
@@ -693,6 +737,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MEWITHSUPPERCASING { get; set; }
 
@@ -703,6 +748,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MeWithPascalCasing { get; set; }
 
@@ -713,6 +759,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("users")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __Users { get; set; }
 
@@ -731,6 +778,7 @@ namespace GraphQL.TestServer
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[][] __UsersMatrix { get; set; }
 
@@ -741,6 +789,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByKind { get; set; }
 
@@ -751,6 +800,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int[] __UsersIds { get; set; }
 
@@ -761,6 +811,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("user")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __User { get; set; }
 
@@ -771,6 +822,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("usersByIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByIds { get; set; }
 
@@ -781,6 +833,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("userKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserKind __UserKind { get; set; }
 
@@ -791,6 +844,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("admin")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __Admin { get; set; }
 
@@ -801,6 +855,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("container")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TypesContainer __Container { get; set; }
 
@@ -829,6 +884,7 @@ namespace GraphQL.TestServer
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -843,6 +899,7 @@ namespace GraphQL.TestServer
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __TopLeft { get; set; }
 
@@ -853,6 +910,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("bottomRight")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __BottomRight { get; set; }
 
@@ -886,6 +944,7 @@ namespace GraphQL.TestServer
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -1009,6 +1068,7 @@ namespace GraphQL.TestServer
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
@@ -1019,6 +1079,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value28")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
@@ -1029,6 +1090,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value29")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
@@ -1039,6 +1101,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("value30")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
@@ -1078,6 +1141,7 @@ namespace GraphQL.TestServer
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Role? __Role { get; set; }
 
@@ -1088,6 +1152,7 @@ namespace GraphQL.TestServer
         }
 
         [JsonPropertyName("loginAttempts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
@@ -1139,6 +1204,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -1158,6 +1224,7 @@ namespace GraphQL.TestServer
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.ClassNameIdenticalToPropertyName.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.ClassNameIdenticalToPropertyName.verified.txt
@@ -4,7 +4,7 @@
 //
 // Do not modify this file manually. Any changes will be lost after regeneration.
 // </auto-generated>
-#pragma warning disable 8618, CS8603, CS1066
+#pragma warning disable 8618, CS8603, CS1066, CS0618
 #nullable enable
 namespace TestApp
 {
@@ -32,6 +32,7 @@ namespace TestApp
     public class Container
     {
         [JsonPropertyName("limit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __Limit { get; set; }
 
@@ -56,6 +57,7 @@ namespace TestApp
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("perVariant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __PerVariant { get; set; }
 
@@ -66,6 +68,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("maybePerVariant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL? __MaybePerVariant { get; set; }
 
@@ -76,6 +79,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("perVariants")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL[] __PerVariants { get; set; }
 
@@ -86,6 +90,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("maybePerVariants")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL[]? __MaybePerVariants { get; set; }
 
@@ -96,6 +101,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("limit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Container __Limit { get; set; }
 
@@ -106,6 +112,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("limits")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Container[] __Limits { get; set; }
 
@@ -116,6 +123,7 @@ namespace TestApp
         }
 
         [JsonPropertyName("userIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public long[] __UserIds { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.ClassNameIdenticalToPropertyName.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.ClassNameIdenticalToPropertyName.verified.txt
@@ -32,8 +32,8 @@ namespace TestApp
     public class Container
     {
         [JsonPropertyName("limit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __Limit { get; set; }
 
         [ZeroQL.GraphQLName("limit")]
@@ -57,8 +57,8 @@ namespace TestApp
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("perVariant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __PerVariant { get; set; }
 
         [ZeroQL.GraphQLName("perVariant")]
@@ -68,8 +68,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("maybePerVariant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL? __MaybePerVariant { get; set; }
 
         [ZeroQL.GraphQLName("maybePerVariant")]
@@ -79,8 +79,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("perVariants")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL[] __PerVariants { get; set; }
 
         [ZeroQL.GraphQLName("perVariants")]
@@ -90,8 +90,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("maybePerVariants")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL[]? __MaybePerVariants { get; set; }
 
         [ZeroQL.GraphQLName("maybePerVariants")]
@@ -101,8 +101,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("limit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Container __Limit { get; set; }
 
         [ZeroQL.GraphQLName("limit")]
@@ -112,8 +112,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("limits")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Container[] __Limits { get; set; }
 
         [ZeroQL.GraphQLName("limits")]
@@ -123,8 +123,8 @@ namespace TestApp
         }
 
         [JsonPropertyName("userIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public long[] __UserIds { get; set; }
 
         [ZeroQL.GraphQLName("userIds")]

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
@@ -8,8 +8,8 @@
         public int Id { get; set; }
 
         [JsonPropertyName("staff")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public StaffZeroQL? []? __Staff { get; set; }
 
         [ZeroQL.GraphQLName("staff")]

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.IdenticalNamesForArrayReplaced.verified.txt
@@ -8,6 +8,7 @@
         public int Id { get; set; }
 
         [JsonPropertyName("staff")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public StaffZeroQL? []? __Staff { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.Interfaces.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.Interfaces.verified.txt
@@ -12,8 +12,8 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IUser __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -33,8 +33,8 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IUser __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -54,8 +54,8 @@
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __TopLeft { get; set; }
 
         [ZeroQL.GraphQLName("topLeft")]
@@ -65,8 +65,8 @@
         }
 
         [JsonPropertyName("bottomRight")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __BottomRight { get; set; }
 
         [ZeroQL.GraphQLName("bottomRight")]
@@ -80,8 +80,8 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IUser __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -101,8 +101,8 @@
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __Center { get; set; }
 
         [ZeroQL.GraphQLName("center")]
@@ -120,8 +120,8 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -170,8 +170,8 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IUser __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.Interfaces.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.Interfaces.verified.txt
@@ -12,6 +12,7 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IUser __Creator { get; set; }
 
@@ -32,6 +33,7 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IUser __Creator { get; set; }
 
@@ -52,6 +54,7 @@
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __TopLeft { get; set; }
 
@@ -62,6 +65,7 @@
         }
 
         [JsonPropertyName("bottomRight")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __BottomRight { get; set; }
 
@@ -76,6 +80,7 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IUser __Creator { get; set; }
 
@@ -96,6 +101,7 @@
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __Center { get; set; }
 
@@ -114,6 +120,7 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Creator { get; set; }
 
@@ -163,6 +170,7 @@
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IUser __Creator { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
@@ -4,7 +4,7 @@
 //
 // Do not modify this file manually. Any changes will be lost after regeneration.
 // </auto-generated>
-#pragma warning disable 8618, CS8603, CS1066
+#pragma warning disable 8618, CS8603, CS1066, CS0618
 #nullable enable
 namespace GraphQLClient
 {
@@ -36,6 +36,7 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __Center { get; set; }
 
@@ -54,6 +55,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Person? __Creator { get; set; }
 
@@ -94,6 +96,7 @@ namespace GraphQLClient
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithError? __ContainerWithError { get; set; }
 
@@ -113,6 +116,7 @@ namespace GraphQLClient
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure __Figure { get; set; }
 
@@ -123,6 +127,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -150,6 +155,7 @@ namespace GraphQLClient
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -204,6 +210,7 @@ namespace GraphQLClient
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __Limit2 { get; set; }
 
@@ -237,6 +244,7 @@ namespace GraphQLClient
     internal class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQLClient.uuid __CreateUserId { get; set; }
 
@@ -247,6 +255,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTime")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTime { get; set; }
 
@@ -257,6 +266,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimes")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
@@ -267,6 +277,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimeOffset")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
@@ -277,6 +288,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeSpan")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeSpan { get; set; }
 
@@ -287,6 +299,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateOnly __DateOnly { get; set; }
 
@@ -297,6 +310,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeOnly { get; set; }
 
@@ -307,6 +321,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("createInstant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQLClient.Instant __CreateInstant { get; set; }
 
@@ -317,6 +332,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __AddUser { get; set; }
 
@@ -331,6 +347,7 @@ namespace GraphQLClient
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserProfileImage { get; set; }
 
@@ -341,6 +358,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addMyProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddMyProfileImage { get; set; }
 
@@ -351,6 +369,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfo")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfo { get; set; }
 
@@ -361,6 +380,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfoWithEmails { get; set; }
 
@@ -371,6 +391,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUserKindPascal")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserKindPascal { get; set; }
 
@@ -381,6 +402,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __AddLimit { get; set; }
 
@@ -391,6 +413,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimitNullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
@@ -401,6 +424,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
@@ -411,6 +435,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2Nullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
@@ -421,6 +446,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit3")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit3? __AddLimit3 { get; set; }
 
@@ -431,6 +457,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimits")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
@@ -441,6 +468,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
@@ -451,6 +479,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addValues")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddValues { get; set; }
 
@@ -509,6 +538,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson __Creator { get; set; }
 
@@ -536,6 +566,7 @@ namespace GraphQLClient
     internal class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Int { get; set; }
 
@@ -546,6 +577,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("object")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Object { get; set; }
 
@@ -556,6 +588,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("containerWithoutError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
@@ -566,6 +599,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("entities")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IEntity[] __Entities { get; set; }
 
@@ -576,6 +610,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figures")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure[] __Figures { get; set; }
 
@@ -586,6 +621,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("circles")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Circle[] __Circles { get; set; }
 
@@ -596,6 +632,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("squares")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Square[] __Squares { get; set; }
 
@@ -610,6 +647,7 @@ namespace GraphQLClient
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public JsonDocument __JsonUsersDocument { get; set; }
 
@@ -632,6 +670,7 @@ namespace GraphQLClient
         public global::GraphQLClient.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public PostContent[] __Posts { get; set; }
 
@@ -642,6 +681,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("image")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ImageContent __Image { get; set; }
 
@@ -652,6 +692,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("text")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TextContent __Text { get; set; }
 
@@ -662,6 +703,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public FigureContent __Figure { get; set; }
 
@@ -672,6 +714,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("me")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Me { get; set; }
 
@@ -682,6 +725,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("currentUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __CurrentUser { get; set; }
 
@@ -693,6 +737,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MEWITHSUPPERCASING { get; set; }
 
@@ -703,6 +748,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MeWithPascalCasing { get; set; }
 
@@ -713,6 +759,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("users")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __Users { get; set; }
 
@@ -731,6 +778,7 @@ namespace GraphQLClient
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[][] __UsersMatrix { get; set; }
 
@@ -741,6 +789,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByKind { get; set; }
 
@@ -751,6 +800,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int[] __UsersIds { get; set; }
 
@@ -761,6 +811,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("user")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __User { get; set; }
 
@@ -771,6 +822,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByIds { get; set; }
 
@@ -781,6 +833,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("userKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserKind __UserKind { get; set; }
 
@@ -791,6 +844,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("admin")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __Admin { get; set; }
 
@@ -801,6 +855,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("container")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TypesContainer __Container { get; set; }
 
@@ -829,6 +884,7 @@ namespace GraphQLClient
     internal class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -843,6 +899,7 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __TopLeft { get; set; }
 
@@ -853,6 +910,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("bottomRight")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __BottomRight { get; set; }
 
@@ -886,6 +944,7 @@ namespace GraphQLClient
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -1009,6 +1068,7 @@ namespace GraphQLClient
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
@@ -1019,6 +1079,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value28")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
@@ -1029,6 +1090,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value29")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
@@ -1039,6 +1101,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value30")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
@@ -1078,6 +1141,7 @@ namespace GraphQLClient
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Role? __Role { get; set; }
 
@@ -1088,6 +1152,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("loginAttempts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
@@ -1139,6 +1204,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -1158,6 +1224,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
@@ -36,8 +36,8 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __Center { get; set; }
 
         [ZeroQL.GraphQLName("center")]
@@ -55,8 +55,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Person? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -96,8 +96,8 @@ namespace GraphQLClient
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithError? __ContainerWithError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithError")]
@@ -116,8 +116,8 @@ namespace GraphQLClient
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -127,8 +127,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -155,8 +155,8 @@ namespace GraphQLClient
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -210,8 +210,8 @@ namespace GraphQLClient
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __Limit2 { get; set; }
 
         [ZeroQL.GraphQLName("limit2")]
@@ -244,8 +244,8 @@ namespace GraphQLClient
     internal class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQLClient.uuid __CreateUserId { get; set; }
 
         [ZeroQL.GraphQLName("createUserId")]
@@ -255,8 +255,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTime")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTime { get; set; }
 
         [ZeroQL.GraphQLName("dateTime")]
@@ -266,8 +266,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimes")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
         [ZeroQL.GraphQLName("dateTimes")]
@@ -277,8 +277,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimeOffset")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
         [ZeroQL.GraphQLName("dateTimeOffset")]
@@ -288,8 +288,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeSpan")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeSpan { get; set; }
 
         [ZeroQL.GraphQLName("timeSpan")]
@@ -299,8 +299,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateOnly __DateOnly { get; set; }
 
         [ZeroQL.GraphQLName("dateOnly")]
@@ -310,8 +310,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeOnly { get; set; }
 
         [ZeroQL.GraphQLName("timeOnly")]
@@ -321,8 +321,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("createInstant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQLClient.Instant __CreateInstant { get; set; }
 
         [ZeroQL.GraphQLName("createInstant")]
@@ -332,8 +332,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __AddUser { get; set; }
 
         [ZeroQL.GraphQLName("addUser")]
@@ -347,8 +347,8 @@ namespace GraphQLClient
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addUserProfileImage")]
@@ -358,8 +358,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addMyProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddMyProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addMyProfileImage")]
@@ -369,8 +369,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfo")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfo { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfo")]
@@ -380,8 +380,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfoWithEmails { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfoWithEmails")]
@@ -391,8 +391,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUserKindPascal")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserKindPascal { get; set; }
 
         [ZeroQL.GraphQLName("addUserKindPascal")]
@@ -402,8 +402,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __AddLimit { get; set; }
 
         [ZeroQL.GraphQLName("addLimit")]
@@ -413,8 +413,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimitNullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimitNullable")]
@@ -424,8 +424,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2")]
@@ -435,8 +435,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2Nullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2Nullable")]
@@ -446,8 +446,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit3")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit3? __AddLimit3 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit3")]
@@ -457,8 +457,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimits")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
         [ZeroQL.GraphQLName("addLimits")]
@@ -468,8 +468,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
         [ZeroQL.GraphQLName("addLowerCaseTypeName")]
@@ -479,8 +479,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addValues")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddValues { get; set; }
 
         [ZeroQL.GraphQLName("addValues")]
@@ -538,8 +538,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -566,8 +566,8 @@ namespace GraphQLClient
     internal class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Int { get; set; }
 
         [ZeroQL.GraphQLName("int")]
@@ -577,8 +577,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("object")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Object { get; set; }
 
         [ZeroQL.GraphQLName("object")]
@@ -588,8 +588,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("containerWithoutError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithoutError")]
@@ -599,8 +599,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("entities")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IEntity[] __Entities { get; set; }
 
         [ZeroQL.GraphQLName("entities")]
@@ -610,8 +610,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figures")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure[] __Figures { get; set; }
 
         [ZeroQL.GraphQLName("figures")]
@@ -621,8 +621,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("circles")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Circle[] __Circles { get; set; }
 
         [ZeroQL.GraphQLName("circles")]
@@ -632,8 +632,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("squares")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Square[] __Squares { get; set; }
 
         [ZeroQL.GraphQLName("squares")]
@@ -647,8 +647,8 @@ namespace GraphQLClient
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public JsonDocument __JsonUsersDocument { get; set; }
 
         [ZeroQL.GraphQLName("jsonUsersDocument")]
@@ -670,8 +670,8 @@ namespace GraphQLClient
         public global::GraphQLClient.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public PostContent[] __Posts { get; set; }
 
         [ZeroQL.GraphQLName("posts")]
@@ -681,8 +681,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("image")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ImageContent __Image { get; set; }
 
         [ZeroQL.GraphQLName("image")]
@@ -692,8 +692,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("text")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TextContent __Text { get; set; }
 
         [ZeroQL.GraphQLName("text")]
@@ -703,8 +703,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public FigureContent __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -714,8 +714,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("me")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Me { get; set; }
 
         [ZeroQL.GraphQLName("me")]
@@ -725,8 +725,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("currentUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __CurrentUser { get; set; }
 
         [ZeroQL.GraphQLName("currentUser")]
@@ -737,8 +737,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MEWITHSUPPERCASING { get; set; }
 
         [ZeroQL.GraphQLName("MEWITHSUPPERCASING")]
@@ -748,8 +748,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MeWithPascalCasing { get; set; }
 
         [ZeroQL.GraphQLName("MeWithPascalCasing")]
@@ -759,8 +759,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("users")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __Users { get; set; }
 
         [ZeroQL.GraphQLName("users")]
@@ -778,8 +778,8 @@ namespace GraphQLClient
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[][] __UsersMatrix { get; set; }
 
         [ZeroQL.GraphQLName("usersMatrix")]
@@ -789,8 +789,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByKind { get; set; }
 
         [ZeroQL.GraphQLName("usersByKind")]
@@ -800,8 +800,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int[] __UsersIds { get; set; }
 
         [ZeroQL.GraphQLName("usersIds")]
@@ -811,8 +811,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("user")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __User { get; set; }
 
         [ZeroQL.GraphQLName("user")]
@@ -822,8 +822,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByIds { get; set; }
 
         [ZeroQL.GraphQLName("usersByIds")]
@@ -833,8 +833,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("userKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserKind __UserKind { get; set; }
 
         [ZeroQL.GraphQLName("userKind")]
@@ -844,8 +844,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("admin")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __Admin { get; set; }
 
         [ZeroQL.GraphQLName("admin")]
@@ -855,8 +855,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("container")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TypesContainer __Container { get; set; }
 
         [ZeroQL.GraphQLName("container")]
@@ -884,8 +884,8 @@ namespace GraphQLClient
     internal class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -899,8 +899,8 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __TopLeft { get; set; }
 
         [ZeroQL.GraphQLName("topLeft")]
@@ -910,8 +910,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("bottomRight")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __BottomRight { get; set; }
 
         [ZeroQL.GraphQLName("bottomRight")]
@@ -944,8 +944,8 @@ namespace GraphQLClient
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -1068,8 +1068,8 @@ namespace GraphQLClient
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
         [ZeroQL.GraphQLName("value27")]
@@ -1079,8 +1079,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value28")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
         [ZeroQL.GraphQLName("value28")]
@@ -1090,8 +1090,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value29")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
         [ZeroQL.GraphQLName("value29")]
@@ -1101,8 +1101,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value30")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
         [ZeroQL.GraphQLName("value30")]
@@ -1141,8 +1141,8 @@ namespace GraphQLClient
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Role? __Role { get; set; }
 
         [ZeroQL.GraphQLName("role")]
@@ -1152,8 +1152,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("loginAttempts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
         [ZeroQL.GraphQLName("loginAttempts")]
@@ -1204,8 +1204,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -1224,8 +1224,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
@@ -4,7 +4,7 @@
 //
 // Do not modify this file manually. Any changes will be lost after regeneration.
 // </auto-generated>
-#pragma warning disable 8618, CS8603, CS1066
+#pragma warning disable 8618, CS8603, CS1066, CS0618
 #nullable enable
 namespace GraphQLClient
 {
@@ -36,6 +36,7 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __Center { get; set; }
 
@@ -54,6 +55,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Person? __Creator { get; set; }
 
@@ -94,6 +96,7 @@ namespace GraphQLClient
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithError? __ContainerWithError { get; set; }
 
@@ -113,6 +116,7 @@ namespace GraphQLClient
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure __Figure { get; set; }
 
@@ -123,6 +127,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -150,6 +155,7 @@ namespace GraphQLClient
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -204,6 +210,7 @@ namespace GraphQLClient
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __Limit2 { get; set; }
 
@@ -237,6 +244,7 @@ namespace GraphQLClient
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQLClient.uuid __CreateUserId { get; set; }
 
@@ -247,6 +255,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTime")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTime { get; set; }
 
@@ -257,6 +266,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimes")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
@@ -267,6 +277,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimeOffset")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
@@ -277,6 +288,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeSpan")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeSpan { get; set; }
 
@@ -287,6 +299,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public DateOnly __DateOnly { get; set; }
 
@@ -297,6 +310,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeOnly")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TimeSpan __TimeOnly { get; set; }
 
@@ -307,6 +321,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("createInstant")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public global::GraphQLClient.Instant __CreateInstant { get; set; }
 
@@ -317,6 +332,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __AddUser { get; set; }
 
@@ -331,6 +347,7 @@ namespace GraphQLClient
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserProfileImage { get; set; }
 
@@ -341,6 +358,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addMyProfileImage")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddMyProfileImage { get; set; }
 
@@ -351,6 +369,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfo")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfo { get; set; }
 
@@ -361,6 +380,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUsersInfoWithEmails { get; set; }
 
@@ -371,6 +391,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUserKindPascal")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddUserKindPascal { get; set; }
 
@@ -381,6 +402,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL __AddLimit { get; set; }
 
@@ -391,6 +413,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimitNullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
@@ -401,6 +424,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
@@ -411,6 +435,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2Nullable")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
@@ -421,6 +446,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit3")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit3? __AddLimit3 { get; set; }
 
@@ -431,6 +457,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimits")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
@@ -441,6 +468,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
@@ -451,6 +479,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addValues")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __AddValues { get; set; }
 
@@ -509,6 +538,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson __Creator { get; set; }
 
@@ -536,6 +566,7 @@ namespace GraphQLClient
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Int { get; set; }
 
@@ -546,6 +577,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("object")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int __Object { get; set; }
 
@@ -556,6 +588,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("containerWithoutError")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
@@ -566,6 +599,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("entities")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IEntity[] __Entities { get; set; }
 
@@ -576,6 +610,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figures")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IFigure[] __Figures { get; set; }
 
@@ -586,6 +621,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("circles")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Circle[] __Circles { get; set; }
 
@@ -596,6 +632,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("squares")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Square[] __Squares { get; set; }
 
@@ -610,6 +647,7 @@ namespace GraphQLClient
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public JsonDocument __JsonUsersDocument { get; set; }
 
@@ -632,6 +670,7 @@ namespace GraphQLClient
         public global::GraphQLClient.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public PostContent[] __Posts { get; set; }
 
@@ -642,6 +681,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("image")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public ImageContent __Image { get; set; }
 
@@ -652,6 +692,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("text")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TextContent __Text { get; set; }
 
@@ -662,6 +703,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figure")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public FigureContent __Figure { get; set; }
 
@@ -672,6 +714,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("me")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Me { get; set; }
 
@@ -682,6 +725,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("currentUser")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __CurrentUser { get; set; }
 
@@ -693,6 +737,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MEWITHSUPPERCASING { get; set; }
 
@@ -703,6 +748,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __MeWithPascalCasing { get; set; }
 
@@ -713,6 +759,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("users")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __Users { get; set; }
 
@@ -731,6 +778,7 @@ namespace GraphQLClient
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[][] __UsersMatrix { get; set; }
 
@@ -741,6 +789,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByKind { get; set; }
 
@@ -751,6 +800,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public int[] __UsersIds { get; set; }
 
@@ -761,6 +811,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("user")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __User { get; set; }
 
@@ -771,6 +822,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByIds")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User[] __UsersByIds { get; set; }
 
@@ -781,6 +833,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("userKind")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserKind __UserKind { get; set; }
 
@@ -791,6 +844,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("admin")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User? __Admin { get; set; }
 
@@ -801,6 +855,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("container")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public TypesContainer __Container { get; set; }
 
@@ -829,6 +884,7 @@ namespace GraphQLClient
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -843,6 +899,7 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __TopLeft { get; set; }
 
@@ -853,6 +910,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("bottomRight")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Point __BottomRight { get; set; }
 
@@ -886,6 +944,7 @@ namespace GraphQLClient
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public User __Author { get; set; }
 
@@ -1009,6 +1068,7 @@ namespace GraphQLClient
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
@@ -1019,6 +1079,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value28")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
@@ -1029,6 +1090,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value29")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
@@ -1039,6 +1101,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value30")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
@@ -1078,6 +1141,7 @@ namespace GraphQLClient
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public Role? __Role { get; set; }
 
@@ -1088,6 +1152,7 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("loginAttempts")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
@@ -1139,6 +1204,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 
@@ -1158,6 +1224,7 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
+        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         public IPerson? __Creator { get; set; }
 

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
@@ -36,8 +36,8 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("center")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __Center { get; set; }
 
         [ZeroQL.GraphQLName("center")]
@@ -55,8 +55,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Person? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -96,8 +96,8 @@ namespace GraphQLClient
         public string Value { get; set; }
 
         [JsonPropertyName("containerWithError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithError? __ContainerWithError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithError")]
@@ -116,8 +116,8 @@ namespace GraphQLClient
         public int Id { get; set; }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -127,8 +127,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -155,8 +155,8 @@ namespace GraphQLClient
         public ImageResolution Resolution { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -210,8 +210,8 @@ namespace GraphQLClient
         public int Value { get; set; }
 
         [JsonPropertyName("limit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __Limit2 { get; set; }
 
         [ZeroQL.GraphQLName("limit2")]
@@ -244,8 +244,8 @@ namespace GraphQLClient
     public class Mutation : global::ZeroQL.Internal.IMutation
     {
         [JsonPropertyName("createUserId")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQLClient.uuid __CreateUserId { get; set; }
 
         [ZeroQL.GraphQLName("createUserId")]
@@ -255,8 +255,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTime")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTime { get; set; }
 
         [ZeroQL.GraphQLName("dateTime")]
@@ -266,8 +266,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimes")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset? []? __DateTimes { get; set; }
 
         [ZeroQL.GraphQLName("dateTimes")]
@@ -277,8 +277,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateTimeOffset")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateTimeOffset __DateTimeOffset { get; set; }
 
         [ZeroQL.GraphQLName("dateTimeOffset")]
@@ -288,8 +288,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeSpan")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeSpan { get; set; }
 
         [ZeroQL.GraphQLName("timeSpan")]
@@ -299,8 +299,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("dateOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public DateOnly __DateOnly { get; set; }
 
         [ZeroQL.GraphQLName("dateOnly")]
@@ -310,8 +310,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("timeOnly")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TimeSpan __TimeOnly { get; set; }
 
         [ZeroQL.GraphQLName("timeOnly")]
@@ -321,8 +321,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("createInstant")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public global::GraphQLClient.Instant __CreateInstant { get; set; }
 
         [ZeroQL.GraphQLName("createInstant")]
@@ -332,8 +332,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __AddUser { get; set; }
 
         [ZeroQL.GraphQLName("addUser")]
@@ -347,8 +347,8 @@ namespace GraphQLClient
         public int DoError { get; set; }
 
         [JsonPropertyName("addUserProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addUserProfileImage")]
@@ -358,8 +358,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addMyProfileImage")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddMyProfileImage { get; set; }
 
         [ZeroQL.GraphQLName("addMyProfileImage")]
@@ -369,8 +369,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfo")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfo { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfo")]
@@ -380,8 +380,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUsersInfoWithEmails")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUsersInfoWithEmails { get; set; }
 
         [ZeroQL.GraphQLName("addUsersInfoWithEmails")]
@@ -391,8 +391,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addUserKindPascal")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddUserKindPascal { get; set; }
 
         [ZeroQL.GraphQLName("addUserKindPascal")]
@@ -402,8 +402,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL __AddLimit { get; set; }
 
         [ZeroQL.GraphQLName("addLimit")]
@@ -413,8 +413,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimitNullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public LimitZeroQL? __AddLimitNullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimitNullable")]
@@ -424,8 +424,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL __AddLimit2 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2")]
@@ -435,8 +435,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit2Nullable")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL? __AddLimit2Nullable { get; set; }
 
         [ZeroQL.GraphQLName("addLimit2Nullable")]
@@ -446,8 +446,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimit3")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit3? __AddLimit3 { get; set; }
 
         [ZeroQL.GraphQLName("addLimit3")]
@@ -457,8 +457,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLimits")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Limit2ZeroQL[] __AddLimits { get; set; }
 
         [ZeroQL.GraphQLName("addLimits")]
@@ -468,8 +468,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addLowerCaseTypeName")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public lower_case_type_name __AddLowerCaseTypeName { get; set; }
 
         [ZeroQL.GraphQLName("addLowerCaseTypeName")]
@@ -479,8 +479,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("addValues")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __AddValues { get; set; }
 
         [ZeroQL.GraphQLName("addValues")]
@@ -538,8 +538,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -566,8 +566,8 @@ namespace GraphQLClient
     public class Query : global::ZeroQL.Internal.IQuery
     {
         [JsonPropertyName("int")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Int { get; set; }
 
         [ZeroQL.GraphQLName("int")]
@@ -577,8 +577,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("object")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int __Object { get; set; }
 
         [ZeroQL.GraphQLName("object")]
@@ -588,8 +588,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("containerWithoutError")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ContainerWithoutError? __ContainerWithoutError { get; set; }
 
         [ZeroQL.GraphQLName("containerWithoutError")]
@@ -599,8 +599,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("entities")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IEntity[] __Entities { get; set; }
 
         [ZeroQL.GraphQLName("entities")]
@@ -610,8 +610,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figures")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IFigure[] __Figures { get; set; }
 
         [ZeroQL.GraphQLName("figures")]
@@ -621,8 +621,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("circles")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Circle[] __Circles { get; set; }
 
         [ZeroQL.GraphQLName("circles")]
@@ -632,8 +632,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("squares")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Square[] __Squares { get; set; }
 
         [ZeroQL.GraphQLName("squares")]
@@ -647,8 +647,8 @@ namespace GraphQLClient
         public global::System.Text.Json.JsonElement JsonUsersElement { get; set; }
 
         [JsonPropertyName("jsonUsersDocument")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public JsonDocument __JsonUsersDocument { get; set; }
 
         [ZeroQL.GraphQLName("jsonUsersDocument")]
@@ -670,8 +670,8 @@ namespace GraphQLClient
         public global::GraphQLClient.ZonedDateTime ZonedDateTime { get; set; }
 
         [JsonPropertyName("posts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public PostContent[] __Posts { get; set; }
 
         [ZeroQL.GraphQLName("posts")]
@@ -681,8 +681,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("image")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public ImageContent __Image { get; set; }
 
         [ZeroQL.GraphQLName("image")]
@@ -692,8 +692,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("text")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TextContent __Text { get; set; }
 
         [ZeroQL.GraphQLName("text")]
@@ -703,8 +703,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("figure")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public FigureContent __Figure { get; set; }
 
         [ZeroQL.GraphQLName("figure")]
@@ -714,8 +714,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("me")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Me { get; set; }
 
         [ZeroQL.GraphQLName("me")]
@@ -725,8 +725,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("currentUser")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __CurrentUser { get; set; }
 
         [ZeroQL.GraphQLName("currentUser")]
@@ -737,8 +737,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MEWITHSUPPERCASING")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MEWITHSUPPERCASING { get; set; }
 
         [ZeroQL.GraphQLName("MEWITHSUPPERCASING")]
@@ -748,8 +748,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("MeWithPascalCasing")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __MeWithPascalCasing { get; set; }
 
         [ZeroQL.GraphQLName("MeWithPascalCasing")]
@@ -759,8 +759,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("users")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __Users { get; set; }
 
         [ZeroQL.GraphQLName("users")]
@@ -778,8 +778,8 @@ namespace GraphQLClient
         public UserKindPascal[] UserKindPascals { get; set; }
 
         [JsonPropertyName("usersMatrix")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[][] __UsersMatrix { get; set; }
 
         [ZeroQL.GraphQLName("usersMatrix")]
@@ -789,8 +789,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByKind { get; set; }
 
         [ZeroQL.GraphQLName("usersByKind")]
@@ -800,8 +800,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public int[] __UsersIds { get; set; }
 
         [ZeroQL.GraphQLName("usersIds")]
@@ -811,8 +811,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("user")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __User { get; set; }
 
         [ZeroQL.GraphQLName("user")]
@@ -822,8 +822,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("usersByIds")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User[] __UsersByIds { get; set; }
 
         [ZeroQL.GraphQLName("usersByIds")]
@@ -833,8 +833,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("userKind")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserKind __UserKind { get; set; }
 
         [ZeroQL.GraphQLName("userKind")]
@@ -844,8 +844,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("admin")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User? __Admin { get; set; }
 
         [ZeroQL.GraphQLName("admin")]
@@ -855,8 +855,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("container")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public TypesContainer __Container { get; set; }
 
         [ZeroQL.GraphQLName("container")]
@@ -884,8 +884,8 @@ namespace GraphQLClient
     public class Square : IFigure, IEntity
     {
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -899,8 +899,8 @@ namespace GraphQLClient
         public int? Id { get; set; }
 
         [JsonPropertyName("topLeft")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __TopLeft { get; set; }
 
         [ZeroQL.GraphQLName("topLeft")]
@@ -910,8 +910,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("bottomRight")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Point __BottomRight { get; set; }
 
         [ZeroQL.GraphQLName("bottomRight")]
@@ -944,8 +944,8 @@ namespace GraphQLClient
         public string Text { get; set; }
 
         [JsonPropertyName("author")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public User __Author { get; set; }
 
         [ZeroQL.GraphQLName("author")]
@@ -1068,8 +1068,8 @@ namespace GraphQLClient
         public Guid[]? Value26 { get; set; }
 
         [JsonPropertyName("value27")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[] __Value27 { get; set; }
 
         [ZeroQL.GraphQLName("value27")]
@@ -1079,8 +1079,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value28")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString[]? __Value28 { get; set; }
 
         [ZeroQL.GraphQLName("value28")]
@@ -1090,8 +1090,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value29")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString __Value29 { get; set; }
 
         [ZeroQL.GraphQLName("value29")]
@@ -1101,8 +1101,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("value30")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public KeyValuePairOfStringAndString? __Value30 { get; set; }
 
         [ZeroQL.GraphQLName("value30")]
@@ -1141,8 +1141,8 @@ namespace GraphQLClient
         public UserKind UserKind { get; set; }
 
         [JsonPropertyName("role")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public Role? __Role { get; set; }
 
         [ZeroQL.GraphQLName("role")]
@@ -1152,8 +1152,8 @@ namespace GraphQLClient
         }
 
         [JsonPropertyName("loginAttempts")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public UserLoginAttempt[] __LoginAttempts { get; set; }
 
         [ZeroQL.GraphQLName("loginAttempts")]
@@ -1204,8 +1204,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]
@@ -1224,8 +1224,8 @@ namespace GraphQLClient
         public double Perimeter { get; set; }
 
         [JsonPropertyName("creator")]
-        [global::System.ObsoleteAttribute("This property is for internal use only.")]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        [global::System.ObsoleteAttribute("This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.")]
         public IPerson? __Creator { get; set; }
 
         [ZeroQL.GraphQLName("creator")]

--- a/src/ZeroQL.Tests/Core/TestExtensions.cs
+++ b/src/ZeroQL.Tests/Core/TestExtensions.cs
@@ -188,7 +188,7 @@ public static class TestExtensions
         var character = span.StartLinePosition.Character;
         var source = sourceTree
             .ToString()
-            .Split('\r');
+            .Split('\n');
 
         var lineWithPreview = source[line].Insert(character, "^");
         

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.QueryPreviewGenerated.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.QueryPreviewGenerated.verified.txt
@@ -1,2 +1,1 @@
-﻿
-        var response = await qlClient^.Query(static q => new { Me = q.Me(o => new { o.FirstName }) });
+﻿        var response = await qlClient.^Query(static q => new { Me = q.Me(o => new { o.FirstName }) });

--- a/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
@@ -160,6 +160,8 @@ public static class TypeGenerator
             .Property("__" + field.Name, field.TypeDefinition, null)
             .AddAttributeWithStringParameter(
                 ZeroQLGenerationInfo.JsonPropertyNameAttribute, field.GraphQLName)
+            .AddAttributeWithStringParameter(
+                ZeroQLGenerationInfo.ObsoleteAttribute, "This property is for internal use only.")
             .AddAttributeWithRawParameters(
                 ZeroQLGenerationInfo.EditorBrowsableAttribute,
                 ZeroQLGenerationInfo.EditorBrowsableNeverParameter);

--- a/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
@@ -160,11 +160,11 @@ public static class TypeGenerator
             .Property("__" + field.Name, field.TypeDefinition, null)
             .AddAttributeWithStringParameter(
                 ZeroQLGenerationInfo.JsonPropertyNameAttribute, field.GraphQLName)
-            .AddAttributeWithStringParameter(
-                ZeroQLGenerationInfo.ObsoleteAttribute, "This property is for internal use only.")
             .AddAttributeWithRawParameters(
                 ZeroQLGenerationInfo.EditorBrowsableAttribute,
-                ZeroQLGenerationInfo.EditorBrowsableNeverParameter);
+                ZeroQLGenerationInfo.EditorBrowsableNeverParameter)
+            .AddAttributeWithStringParameter(ZeroQLGenerationInfo.ObsoleteAttribute,
+                "This property is for internal use only. Do not use it directly. It maybe be removed in the future releases.");
     }
 
     public static MemberDeclarationSyntax[] GeneratePropertiesDeclarations(this FieldDefinition field,

--- a/src/ZeroQL.Tools/Bootstrap/GraphQLGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/GraphQLGenerator.cs
@@ -96,7 +96,7 @@ public static class GraphQLGenerator
         namespaceDeclaration = namespaceDeclaration
             .WithMembers(members);
 
-        var warningCodes = options.WarningsToIgnore ?? new[] { "8618", "CS8603", "CS1066" };
+        var warningCodes = options.WarningsToIgnore ?? new[] { "8618", "CS8603", "CS1066", "CS0618" };
         var disableWarning = PragmaWarningDirectiveTrivia(Token(SyntaxKind.DisableKeyword), true)
             .WithErrorCodes(
                 SeparatedList<ExpressionSyntax>(warningCodes

--- a/src/ZeroQL.Tools/ZeroQLGenerationInfo.cs
+++ b/src/ZeroQL.Tools/ZeroQLGenerationInfo.cs
@@ -15,6 +15,8 @@ public class ZeroQLGenerationInfo
 
     public static string EditorBrowsableAttribute => "global::System.ComponentModel.EditorBrowsable";
 
+    public static string ObsoleteAttribute => "global::System.ObsoleteAttribute";
+
     public static string EditorBrowsableNeverParameter => "global::System.ComponentModel.EditorBrowsableState.Never";
 
     public static string JsonIgnoreAttribute => "JsonIgnore";


### PR DESCRIPTION
I have noticed that some developers are using internal properties with prefix "__". It is a bad idea because they maybe be removed in the future.

This PR adds obsolete attribute to warn about it.