### PR TITLE
Fix null reference exception

### DIFF
--- a/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
+++ b/src/ZeroQL.SourceGenerators/Resolver/GraphQLSourceResolver.cs
@@ -57,18 +57,6 @@ namespace {semanticModel.Compilation.Assembly.Name}
                 return content;
             }});
 
-            if (qlResponse is null)
-            {{
-                return new GraphQLResult<{context.QueryTypeName}>
-                {{
-                    HttpResponseMessage = qlResponse.HttpResponseMessage,
-                    Errors = new[]
-                    {{
-                        new GraphQueryError {{ Message = ""Failed to deserialize response"" }}
-                    }}
-                }};
-            }}
-
             return new GraphQLResult<{context.QueryTypeName}>
             {{
                 HttpResponseMessage = qlResponse.HttpResponseMessage,

--- a/src/ZeroQL.Tests/SourceGeneration/FileUploadTests.UploadFileGenerates.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/FileUploadTests.UploadFileGenerates.verified.txt
@@ -61,18 +61,6 @@ namespace ZeroQL.TestApp
                 return content;
             });
 
-            if (qlResponse is null)
-            {
-                return new GraphQLResult<global::GraphQL.TestServer.Mutation>
-                {
-                    HttpResponseMessage = qlResponse.HttpResponseMessage,
-                    Errors = new[]
-                    {
-                        new GraphQueryError { Message = "Failed to deserialize response" }
-                    }
-                };
-            }
-
             return new GraphQLResult<global::GraphQL.TestServer.Mutation>
             {
                 HttpResponseMessage = qlResponse.HttpResponseMessage,

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.LambdaModuleInitializerGenerated.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.LambdaModuleInitializerGenerated.verified.txt
@@ -45,18 +45,6 @@ namespace ZeroQL.TestApp
                 return content;
             });
 
-            if (qlResponse is null)
-            {
-                return new GraphQLResult<global::GraphQL.TestServer.Query>
-                {
-                    HttpResponseMessage = qlResponse.HttpResponseMessage,
-                    Errors = new[]
-                    {
-                        new GraphQueryError { Message = "Failed to deserialize response" }
-                    }
-                };
-            }
-
             return new GraphQLResult<global::GraphQL.TestServer.Query>
             {
                 HttpResponseMessage = qlResponse.HttpResponseMessage,


### PR DESCRIPTION
The generated code is incorrect as it tries to access the property `HttpResponseMessage` on `qlResponse` when `qlResponse` is null.

Looking at the types the `IGraphQLQueryPipeline.ExecuteAsync` so I think we can safely remove the null check.

If not then `HttpResponseMessage` on `GraphQLResult` would need to be reverted to be nullable since you do not have that information in the null case.