### PR TITLE
Fix for DateTime test when working in other time zones

### DIFF
--- a/src/ZeroQL.Tests/SourceGeneration/DateTests.Dates_name=DateTime.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/DateTests.Dates_name=DateTime.verified.txt
@@ -1,4 +1,4 @@
 {
   Query: mutation ($input: DateTime!) { dateTime(dateTime: $input)},
-  Data: 2042-12-11 08:09:08.007 +0
+  Data: 2042-12-11 10:09:08.007 +0
 }

--- a/src/ZeroQL.Tests/SourceGeneration/DateTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/DateTests.cs
@@ -6,7 +6,7 @@ namespace ZeroQL.Tests.SourceGeneration;
 public class DateTests : IntegrationTest
 {
     [Theory]
-    [InlineData("DateTime", "new DateTime(2042, 12, 11, 10, 9, 8, 7, DateTimeKind.Local)")]
+    [InlineData("DateTime", "new DateTime(2042, 12, 11, 10, 9, 8, 7, DateTimeKind.Utc)")]
     [InlineData("DateTimes", "new [] { new DateTimeOffset(2042, 12, 11, 10, 9, 8, 7, TimeSpan.FromHours(1)) }")]
     [InlineData("DateTimeOffset", "new DateTimeOffset(2042, 12, 11, 10, 9, 8, 7, TimeSpan.FromHours(1))")]
     [InlineData("TimeSpan", "new TimeSpan(7, 6, 5, 4, 3)")]


### PR DESCRIPTION
Just a small fix for a test to make sure that all tests can run green no matter the timezone.