### PR TITLE
Add required keyword for non-nullable input type properties

### DIFF
--- a/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
+++ b/src/TestApp/ZeroQL.TestApp/Generated/GraphQL.g.cs
@@ -1301,11 +1301,11 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("key")]
         [ZeroQL.GraphQLName("key")]
-        public string Key { get; set; }
+        public required string Key { get; set; }
 
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public string Value { get; set; }
+        public required string Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1314,7 +1314,7 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
 
         [JsonPropertyName("limit2")]
         [ZeroQL.GraphQLName("limit2")]
@@ -1327,7 +1327,7 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("limit3Input")]
         [ZeroQL.GraphQLName("limit3Input")]
-        public int Limit3Input { get; set; }
+        public required int Limit3Input { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1336,11 +1336,11 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("limit")]
         [ZeroQL.GraphQLName("limit")]
-        public int Limit { get; set; }
+        public required int Limit { get; set; }
 
         [JsonPropertyName("limitInput")]
         [ZeroQL.GraphQLName("limitInput")]
-        public int LimitInput { get; set; }
+        public required int LimitInput { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1349,7 +1349,7 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1358,11 +1358,11 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("count")]
         [ZeroQL.GraphQLName("count")]
-        public int Count { get; set; }
+        public required int Count { get; set; }
 
         [JsonPropertyName("size")]
         [ZeroQL.GraphQLName("size")]
-        public int Size { get; set; }
+        public required int Size { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1371,7 +1371,7 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("userKind")]
         [ZeroQL.GraphQLName("userKind")]
-        public UserKind UserKind { get; set; }
+        public required UserKind UserKind { get; set; }
 
         [JsonPropertyName("page")]
         [ZeroQL.GraphQLName("page")]
@@ -1384,15 +1384,15 @@ namespace GraphQL.TestServer
     {
         [JsonPropertyName("firstName")]
         [ZeroQL.GraphQLName("firstName")]
-        public string FirstName { get; set; }
+        public required string FirstName { get; set; }
 
         [JsonPropertyName("lastName")]
         [ZeroQL.GraphQLName("lastName")]
-        public string LastName { get; set; }
+        public required string LastName { get; set; }
 
         [JsonPropertyName("avatar")]
         [ZeroQL.GraphQLName("avatar")]
-        public global::ZeroQL.Upload Avatar { get; set; }
+        public required global::ZeroQL.Upload Avatar { get; set; }
     }
 
     public sealed record ZonedDateTime : ZeroQLScalar

--- a/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.RequiredModifierForInputProperties.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/CustomSchemaParseTests.RequiredModifierForInputProperties.verified.txt
@@ -1,0 +1,62 @@
+﻿{
+  TestInput:
+    [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
+    [ZeroQL.GraphQLType("TestInput")]
+    public partial class TestInput
+    {
+        [JsonPropertyName("requiredField")]
+        [ZeroQL.GraphQLName("requiredField")]
+        public required string RequiredField { get; set; }
+
+        [JsonPropertyName("requiredWithDefault")]
+        [ZeroQL.GraphQLName("requiredWithDefault")]
+        public string RequiredWithDefault { get; set; } = "default";
+
+        [JsonPropertyName("optionalField")]
+        [ZeroQL.GraphQLName("optionalField")]
+        public string? OptionalField { get; set; }
+
+        [JsonPropertyName("optionalWithDefault")]
+        [ZeroQL.GraphQLName("optionalWithDefault")]
+        public string? OptionalWithDefault { get; set; } = "default";
+
+        [JsonPropertyName("nestedInput")]
+        [ZeroQL.GraphQLName("nestedInput")]
+        public required NestedInput NestedInput { get; set; }
+
+        [JsonPropertyName("optionalNestedInput")]
+        [ZeroQL.GraphQLName("optionalNestedInput")]
+        public NestedInput? OptionalNestedInput { get; set; }
+
+        [JsonPropertyName("requiredList")]
+        [ZeroQL.GraphQLName("requiredList")]
+        public required string[] RequiredList { get; set; }
+
+        [JsonPropertyName("optionalList")]
+        [ZeroQL.GraphQLName("optionalList")]
+        public string[]? OptionalList { get; set; }
+
+        [JsonPropertyName("requiredInt")]
+        [ZeroQL.GraphQLName("requiredInt")]
+        public required int RequiredInt { get; set; }
+
+        [JsonPropertyName("optionalInt")]
+        [ZeroQL.GraphQLName("optionalInt")]
+        public int? OptionalInt { get; set; }
+
+        [JsonPropertyName("requiredIntWithDefault")]
+        [ZeroQL.GraphQLName("requiredIntWithDefault")]
+        public int RequiredIntWithDefault { get; set; } = 42;
+    }
+,
+  NestedInput:
+    [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
+    [ZeroQL.GraphQLType("NestedInput")]
+    public partial class NestedInput
+    {
+        [JsonPropertyName("value")]
+        [ZeroQL.GraphQLName("value")]
+        public required string Value { get; set; }
+    }
+
+}

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.InternalClient.verified.txt
@@ -1301,11 +1301,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("key")]
         [ZeroQL.GraphQLName("key")]
-        public string Key { get; set; }
+        public required string Key { get; set; }
 
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public string Value { get; set; }
+        public required string Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1314,7 +1314,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
 
         [JsonPropertyName("limit2")]
         [ZeroQL.GraphQLName("limit2")]
@@ -1327,7 +1327,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("limit3Input")]
         [ZeroQL.GraphQLName("limit3Input")]
-        public int Limit3Input { get; set; }
+        public required int Limit3Input { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1336,11 +1336,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("limit")]
         [ZeroQL.GraphQLName("limit")]
-        public int Limit { get; set; }
+        public required int Limit { get; set; }
 
         [JsonPropertyName("limitInput")]
         [ZeroQL.GraphQLName("limitInput")]
-        public int LimitInput { get; set; }
+        public required int LimitInput { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1349,7 +1349,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1358,11 +1358,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("count")]
         [ZeroQL.GraphQLName("count")]
-        public int Count { get; set; }
+        public required int Count { get; set; }
 
         [JsonPropertyName("size")]
         [ZeroQL.GraphQLName("size")]
-        public int Size { get; set; }
+        public required int Size { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1371,7 +1371,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("userKind")]
         [ZeroQL.GraphQLName("userKind")]
-        public UserKind UserKind { get; set; }
+        public required UserKind UserKind { get; set; }
 
         [JsonPropertyName("page")]
         [ZeroQL.GraphQLName("page")]
@@ -1384,15 +1384,15 @@ namespace GraphQLClient
     {
         [JsonPropertyName("firstName")]
         [ZeroQL.GraphQLName("firstName")]
-        public string FirstName { get; set; }
+        public required string FirstName { get; set; }
 
         [JsonPropertyName("lastName")]
         [ZeroQL.GraphQLName("lastName")]
-        public string LastName { get; set; }
+        public required string LastName { get; set; }
 
         [JsonPropertyName("avatar")]
         [ZeroQL.GraphQLName("avatar")]
-        public global::ZeroQL.Upload Avatar { get; set; }
+        public required global::ZeroQL.Upload Avatar { get; set; }
     }
 
     internal sealed record Instant : ZeroQLScalar

--- a/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
+++ b/src/ZeroQL.Tests/Bootstrap/ParseSchemaTests.PublicClient.verified.txt
@@ -1301,11 +1301,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("key")]
         [ZeroQL.GraphQLName("key")]
-        public string Key { get; set; }
+        public required string Key { get; set; }
 
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public string Value { get; set; }
+        public required string Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1314,7 +1314,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
 
         [JsonPropertyName("limit2")]
         [ZeroQL.GraphQLName("limit2")]
@@ -1327,7 +1327,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("limit3Input")]
         [ZeroQL.GraphQLName("limit3Input")]
-        public int Limit3Input { get; set; }
+        public required int Limit3Input { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1336,11 +1336,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("limit")]
         [ZeroQL.GraphQLName("limit")]
-        public int Limit { get; set; }
+        public required int Limit { get; set; }
 
         [JsonPropertyName("limitInput")]
         [ZeroQL.GraphQLName("limitInput")]
-        public int LimitInput { get; set; }
+        public required int LimitInput { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1349,7 +1349,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("value")]
         [ZeroQL.GraphQLName("value")]
-        public int Value { get; set; }
+        public required int Value { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1358,11 +1358,11 @@ namespace GraphQLClient
     {
         [JsonPropertyName("count")]
         [ZeroQL.GraphQLName("count")]
-        public int Count { get; set; }
+        public required int Count { get; set; }
 
         [JsonPropertyName("size")]
         [ZeroQL.GraphQLName("size")]
-        public int Size { get; set; }
+        public required int Size { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode ( "ZeroQL" ,  "1.0.0.0" )]
@@ -1371,7 +1371,7 @@ namespace GraphQLClient
     {
         [JsonPropertyName("userKind")]
         [ZeroQL.GraphQLName("userKind")]
-        public UserKind UserKind { get; set; }
+        public required UserKind UserKind { get; set; }
 
         [JsonPropertyName("page")]
         [ZeroQL.GraphQLName("page")]
@@ -1384,15 +1384,15 @@ namespace GraphQLClient
     {
         [JsonPropertyName("firstName")]
         [ZeroQL.GraphQLName("firstName")]
-        public string FirstName { get; set; }
+        public required string FirstName { get; set; }
 
         [JsonPropertyName("lastName")]
         [ZeroQL.GraphQLName("lastName")]
-        public string LastName { get; set; }
+        public required string LastName { get; set; }
 
         [JsonPropertyName("avatar")]
         [ZeroQL.GraphQLName("avatar")]
-        public global::ZeroQL.Upload Avatar { get; set; }
+        public required global::ZeroQL.Upload Avatar { get; set; }
     }
 
     public sealed record Instant : ZeroQLScalar

--- a/src/ZeroQL.Tests/SourceGeneration/MutationTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/MutationTests.cs
@@ -84,7 +84,7 @@ public class MutationTests : IntegrationTest
     public async Task ReplacementTypeWorks()
     {
         var csharpQuery = """
-                var limit = new LimitInputZeroQL { Limit = 10 };
+                var limit = new LimitInputZeroQL { Limit = 10, LimitInput = 20 };
                 var response = await qlClient.Mutation(m => m.AddLimit(limit, o => o.Limit));
                 """;
 

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.CombinationNullableAndNonNullable.verified.txt
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.CombinationNullableAndNonNullable.verified.txt
@@ -1,10 +1,16 @@
 ﻿{
   response: {
     Query: mutation ($limit: LimitInput!) { addLimitNullable(limit: $limit) { limit }  addLimit(limit: $limit) { limit } },
-    Data: {}
+    Data: {
+      Limit2: 10,
+      Limit: 10
+    }
   },
   response2: {
     Query: mutation ($limit: LimitInput!) { addLimit(limit: $limit) { limit }  addLimitNullable(limit: $limit) { limit } },
-    Data: {}
+    Data: {
+      Limit: 10,
+      Limit2: 10
+    }
   }
 }

--- a/src/ZeroQL.Tests/SourceGeneration/QueryTests.cs
+++ b/src/ZeroQL.Tests/SourceGeneration/QueryTests.cs
@@ -496,7 +496,7 @@ public class QueryTests : IntegrationTest
     public async Task CombinationNullableAndNonNullable()
     {
         var csharpQuery = """
-                              var limit = new LimitInputZeroQL();
+                              var limit = new LimitInputZeroQL { Limit = 10, LimitInput = 20 };
                               var response = await qlClient.Mutation(m => new
                               {
                                   Limit2 = m.AddLimitNullable(limit, o => o.Limit),
@@ -510,7 +510,7 @@ public class QueryTests : IntegrationTest
         var response = await project.Execute();
 
         var csharpQuery2 = """
-                               var limit = new LimitInputZeroQL();
+                               var limit = new LimitInputZeroQL { Limit = 10, LimitInput = 20 };
                                var response = await qlClient.Mutation(m => new
                                {
                                    Limit = m.AddLimit(limit, o => o.Limit),

--- a/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
+++ b/src/ZeroQL.Tools/Bootstrap/Generators/TypeGenerator.cs
@@ -135,16 +135,21 @@ public static class TypeGenerator
         this GraphQlGeneratorOptions options,
         ClassDefinition[] inputs)
     {
+        var netstandardCompatibility = options.NetstandardCompatibility ?? false;
+
         return inputs
             .Select(o =>
             {
                 var fields = o.Properties
                     .Select(property =>
-                        CSharpHelper.Property(property.Name, property.TypeDefinition, property.DefaultValue)
+                    {
+                        var isRequired = !property.TypeDefinition.CanBeNull;
+                        return CSharpHelper.Property(property.Name, property.TypeDefinition, property.DefaultValue, isRequired, netstandardCompatibility)
                             .AddAttributeWithStringParameter(ZeroQLGenerationInfo.JsonPropertyNameAttribute,
                                 property.GraphQLName)
                             .AddAttributeWithStringParameter(ZeroQLGenerationInfo.GraphQLNameAttribute,
-                                property.GraphQLName));
+                                property.GraphQLName);
+                    });
 
                 return CSharpHelper.Class(o.Name, options.Visibility)
                     .AddAttributeWithStringParameter(ZeroQLGenerationInfo.CodeGenerationAttribute)

--- a/src/ZeroQL.Tools/Internal/CSharpHelper.cs
+++ b/src/ZeroQL.Tools/Internal/CSharpHelper.cs
@@ -57,7 +57,7 @@ internal static class CSharpHelper
                 .AddAttributes(attribute));
     }
 
-    public static PropertyDeclarationSyntax Property(string name, TypeDefinition type, string? defaultValue)
+    public static PropertyDeclarationSyntax Property(string name, TypeDefinition type, string? defaultValue, bool isRequired = false, bool netstandardCompatibility = false)
     {
         var fullTypeName = GetPropertyType(type, false);
 
@@ -68,6 +68,14 @@ internal static class CSharpHelper
                     .WithSemicolonToken(ParseToken(";")),
                 AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
                     .WithSemicolonToken(ParseToken(";")));
+
+        // Add 'required' modifier for required properties without default values
+        // Skip if netstandard compatibility is enabled (required keyword is C# 11+)
+        if (isRequired && defaultValue is null && !netstandardCompatibility)
+        {
+            propertyDeclarationSyntax = propertyDeclarationSyntax
+                .AddModifiers(Token(SyntaxKind.RequiredKeyword));
+        }
 
         var initializerExpression = GetInitializerExpression(type, defaultValue);
         if (initializerExpression is not null)

--- a/src/ZeroQL.Tools/ZeroQL.Tools.csproj
+++ b/src/ZeroQL.Tools/ZeroQL.Tools.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="GraphQL-Parser" Version="9.5.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds C# 11 `required` keyword for non-nullable input type properties without default values
- Provides compile-time validation instead of runtime errors when required fields are missing
- Respects `NetstandardCompatibility` setting to disable `required` keyword for older targets

## Changes
- **CSharpHelper.cs**: Added `isRequired` and `netstandardCompatibility` parameters to `Property` method
- **TypeGenerator.cs**: Pass required info based on nullability and netstandard compatibility
- **ZeroQL.Tools.csproj**: Upgraded `Microsoft.CodeAnalysis.CSharp` to 4.8.0 for `RequiredKeyword` support

## Edge Cases Handled
| GraphQL Field | Generated C# | Has `required`? |
|---------------|--------------|-----------------|
| `name: String!` | `public required string Name { get; set; }` | ✅ Yes |
| `name: String! = "default"` | `public string Name { get; set; } = "default";` | ❌ No |
| `name: String` | `public string? Name { get; set; }` | ❌ No |
| `name: String = "default"` | `public string? Name { get; set; } = "default";` | ❌ No |
| `user: UserInput!` | `public required UserInput User { get; set; }` | ✅ Yes |
| `items: [String!]!` | `public required string[] Items { get; set; }` | ✅ Yes |

## Test plan
- [x] Added `RequiredModifierForInputProperties` test covering all edge cases
- [x] Added `RequiredModifierDisabledWithNetstandardCompatibility` test
- [x] Updated existing tests to use required properties
- [x] Updated snapshot files

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)